### PR TITLE
Updated version of Node, npm, gulp-sass and frontend-maven-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,7 +593,7 @@
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>0.0.23</version>
+				<version>0.0.25</version>
 
 				<configuration>
 					<workingDirectory>src/main/web</workingDirectory>
@@ -606,8 +606,8 @@
 					        <goal>install-node-and-npm</goal>
 					    </goals>
 					    <configuration>
-					        <nodeVersion>v0.10.36</nodeVersion>
-					        <npmVersion>1.4.12</npmVersion>
+					        <nodeVersion>v0.12.7</nodeVersion>
+					        <npmVersion>2.11.3</npmVersion>
 
 					    </configuration>
 					</execution>

--- a/src/main/web/README.md
+++ b/src/main/web/README.md
@@ -10,13 +10,19 @@ Do **NOT** edit files under `/WEB-INF/pages` or `/WEB-INF/static` directly. Thes
 
 # Building
 
+## Node
+
+You will need to have Node.js [v0.12.7](https://nodejs.org/dist/v0.12.7/) installed. If you are running on Windows, this will need to be the 64 bit version of Node due to bitness issues with node-sass running Node locally vs from the frontend-maven-plugin.
+
 ## Maven
 
-When an ordinary Maven build is run, a clean and build is trigger through the use of a maven-node-gulp plugin. This will run a clean, deleting the `/WEB-INF/pages` and `/WEB-INF/static` folders and will rebuild everything from scratch. The WEB-INF folder will then be included in the war file that can be deployed to Tomcat.
+When an ordinary Maven build (`mvn clean install`) is run we use the maven-node-gulp plugin to install Node.js and npm. Then it runs a gulp clean and build. The clean will delete the `/WEB-INF/pages` and `/WEB-INF/static` folders and will rebuild everything from scratch. The WEB-INF folder will then be included in the war file that can be deployed to Tomcat.
 
 ## Gulp
 
-To use the gulp tasks directly, you need to install Node and run `npm install` in this directory to download the required packages. You can then run the Gulp build task directly with `gulp build`. There are also a number of other tasks that you can run manually (that will be included in a build):
+To use the gulp tasks directly, you will need to run a `mvn clean install` in the top level of Workbench. This will run `npm install` as part of the task and install the Node modules required for Workbench front end development.
+
+You can then run the gulp build task directly with `gulp build`. There are also a number of other tasks that you can run manually (that will be included in a build):
 
 * `clean` - removes `/WEB-INF/static` and `/WEB-INF/pages`
 * `build` - runs `'js'`, `'sass'`, `'images'`, `'html'`, `'fonts'`, `'angular'` and `'resources'`. Running with the `--release` flag will minify JS and CSS.
@@ -43,9 +49,9 @@ We must build our files for production with the `--release` flag. This will mini
 
 When developing in a web environment, it is useful to not have to re-build and deploy war files every time you want to test a change. We have added tools to enable this. To enable this, call:
 
-`gulp watch --env=property`
+`gulp watch --env=<property>`
 
-where `property` is a property defined in the `gulp.properties` file specifying the location of your Tomcat installation. This will watch your source folder for changes, and as you develop, will trigger the correct tasks and copy files over the build folder as necessary. In addition to this, **changed files will be copied directly into the exploded Workbench folder in your Tomcat webapps directory**, allowing you to refresh your browser and see changes without redeploying.
+where `<property>` is a property defined in the `gulp.properties` file specifying the location of your Tomcat installation. This will watch your source folder for changes, and as you develop, will trigger the correct tasks and copy files over the build folder as necessary. In addition to this, **changed files will be copied directly into the exploded Workbench folder in your Tomcat webapps directory**, allowing you to refresh your browser and see changes without redeploying.
 
 In addtion to this, there are a few things to note about developing in this environment:
 

--- a/src/main/web/package.json
+++ b/src/main/web/package.json
@@ -40,7 +40,7 @@
     "gulp-pixrem": "^0.1.1",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.2",
-    "gulp-sass": "^1.3.2",
+    "gulp-sass": "^2.0.4",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "jasmine-core": "^2.1.3",


### PR DESCRIPTION
This is to ensure that our development environment works correctly with our gulp-sass plugin. Currently if a developer has a newer version of node than v0.10.x the gulp-sass plugin will cause issues (due to node-sass and libsass). Upgrading the dependencies fixes these issues and means we can work with a newer version of Node.

Issue: none
Reviewer: Iryna
