### PR TITLE
BMS-1797 - Updating the default transaction timeout to 10 minutes

### DIFF
--- a/src/main/resources/jta.properties
+++ b/src/main/resources/jta.properties
@@ -5,3 +5,4 @@ com.atomikos.icatch.service=com.atomikos.icatch.standalone.UserTransactionServic
 com.atomikos.icatch.console_log_level=WARN
 com.atomikos.icatch.serial_jta_transactions=false
 com.atomikos.icatch.max_actives=-1
+com.atomikos.icatch.max_timeout=600000


### PR DESCRIPTION
This is so that large operations such as saving a nursery with 40000 germplasm have enough time to succeed.

issues: BMS-1797
reviewer: MatthewB
