### PR TITLE
Updating timeout when accessing ontology services through the OM

### DIFF
--- a/src/main/web/src/apps/ontology/shared-services/dataTypes.js
+++ b/src/main/web/src/apps/ontology/shared-services/dataTypes.js
@@ -21,7 +21,7 @@
 
 			*/
 			getDataTypes: function() {
-				var request = $http.get('/bmsapi/ontology/datatypes', {timeout: 5000});
+				var request = $http.get('/bmsapi/ontology/datatypes', {timeout: 60000});
 				return request.then(successHandler, failureHandler);
 			},
 

--- a/src/main/web/src/apps/ontology/shared-services/methods.js
+++ b/src/main/web/src/apps/ontology/shared-services/methods.js
@@ -26,7 +26,7 @@
 			getMethods: function() {
 
 				var url = '/bmsapi/ontology/' + configService.getCropName() + '/methods',
-					request = $http.get(url, {timeout: 5000});
+					request = $http.get(url, {timeout: 60000});
 
 				return request.then(successHandler, failureHandler);
 			},

--- a/src/main/web/src/apps/ontology/shared-services/properties.js
+++ b/src/main/web/src/apps/ontology/shared-services/properties.js
@@ -49,7 +49,7 @@
 			*/
 			getProperties: function() {
 				var url = '/bmsapi/ontology/' + configService.getCropName() + '/properties',
-					request = $http.get(url, {timeout: 5000});
+					request = $http.get(url, {timeout: 60000});
 				return request.then(successHandler, failureHandler);
 			},
 

--- a/src/main/web/src/apps/ontology/shared-services/scales.js
+++ b/src/main/web/src/apps/ontology/shared-services/scales.js
@@ -32,7 +32,7 @@
 			}]
 			*/
 			getScales: function() {
-				var request = $http.get('/bmsapi/ontology/' + configService.getCropName() + '/scales'/*, {timeout: 5000}*/);
+				var request = $http.get('/bmsapi/ontology/' + configService.getCropName() + '/scales', {timeout: 60000});
 				return request.then(successHandler, failureHandler);
 			},
 

--- a/src/main/web/src/apps/ontology/shared-services/variableTypes.js
+++ b/src/main/web/src/apps/ontology/shared-services/variableTypes.js
@@ -20,7 +20,7 @@
 			}]
 			*/
 			getTypes: function() {
-				var request = $http.get('/bmsapi/ontology/variableTypes', {timeout: 5000});
+				var request = $http.get('/bmsapi/ontology/variableTypes', {timeout: 60000});
 				return request.then(successHandler, failureHandler);
 			}
 		};

--- a/src/main/web/src/apps/ontology/shared-services/variables.js
+++ b/src/main/web/src/apps/ontology/shared-services/variables.js
@@ -79,7 +79,7 @@
 			*/
 			getVariables: function() {
 				var request = $http.get('/bmsapi/ontology/' + configService.getCropName() + '/variables?programId=' +
-					configService.getProgramId(), {timeout: 10000});
+					configService.getProgramId(), {timeout: 60000});
 				return request.then(successHandler, failureHandler);
 			},
 
@@ -88,7 +88,7 @@
 			*/
 			getFavouriteVariables: function() {
 				var request = $http.get('/bmsapi/ontology/' + configService.getCropName() + '/variables?favourite=true&programId=' +
-					configService.getProgramId(), {timeout: 10000});
+					configService.getProgramId(), {timeout: 60000});
 				return request.then(successHandler, failureHandler);
 			},
 


### PR DESCRIPTION
This is done so that variables, scales, methods and properties load on slower connections.

issue: BMS-2099
reviewer: IrynaD
