### PR TITLE
BMS-2724 Updating our JTA properties to be more consistent

### DIFF
--- a/src/main/resources/jta.properties
+++ b/src/main/resources/jta.properties
@@ -5,4 +5,5 @@ com.atomikos.icatch.service=com.atomikos.icatch.standalone.UserTransactionServic
 com.atomikos.icatch.console_log_level=WARN
 com.atomikos.icatch.serial_jta_transactions=false
 com.atomikos.icatch.max_actives=-1
-com.atomikos.icatch.max_timeout=500000
+com.atomikos.icatch.max_timeout=300000
+com.atomikos.icatch.default_jta_timeout=300000


### PR DESCRIPTION
We have updated the max JTA transaction timeout and max default timeout to the same value.

We have chosen 5 minutes as operations requiring longer need to be coded as a batch process.

issue: BMS-2724
reviewer: MatthewB
