### PR TITLE
Fix Text outside button in Ontology Manager

### DIFF
--- a/src/main/web/src/apps/ontology/app-components/variable-details-view/variableDetails.html
+++ b/src/main/web/src/apps/ontology/app-components/variable-details-view/variableDetails.html
@@ -49,11 +49,11 @@
         <div ng-class="formGroupClass('omIsFavourite', 'isFavourite')" ng-if="editing">
             <label class="col-sm-3 control-label"></label>
             <div class="col-sm-9">
-                <button class="btn btn-default btn-sm col-sm-5" ng-show="editing && !model.favourite" ng-click="debouncedToggleFavourites(variableId, model)">
+                <button class="btn btn-default btn-sm" ng-show="editing && !model.favourite" ng-click="debouncedToggleFavourites(variableId, model)">
                     <span class="glyphicon glyphicon-star"></span> {{'button.addToFavourite' | translate}}
                 </button>
 
-                <button class="btn btn-default btn-sm col-sm-5" ng-show="editing && model.favourite" ng-click="debouncedToggleFavourites(variableId, model)">
+                <button class="btn btn-default btn-sm" ng-show="editing && model.favourite" ng-click="debouncedToggleFavourites(variableId, model)">
                     {{'button.removeFromFavourite' | translate}}  </button>
             </div>
         </div>


### PR DESCRIPTION
Some of the text from the removeFromFavourite button was showing outside
it, due to the class "col-sm-5". Simply remove this class so that the
button can adjust to the content.  Apply the same fix to the
addToFavourite button.

BMS-2475
