### PR TITLE
IBP-3431 Rewrite authorize screen

### DIFF
--- a/src/main/web/src/js/login.js
+++ b/src/main/web/src/js/login.js
@@ -6,8 +6,10 @@
 	var $checkButton = $('.js-login-check'),
 		$checkInput = $('.js-login-checkbox-input'),
 		$loginForm = $('.js-login-form'),
+		$authorizeForm = $('#authorize-form'),
 		$loginModeToggle = $('.js-login-mode-toggle'),
 		$loginSubmit = $('.js-login-submit'),
+		$authorizeSubmit = $('.js-authorize-submit'),
 		$error = $('.js-login-error'),
 		$errorText = $('.js-login-error-text'),
 		$fakeUsername = $('.js-fake-username'),
@@ -33,8 +35,6 @@
 
 	var display_name = getUrlParameter("display_name");
 	var return_url = getUrlParameter("return_url");
-	var token = '';
-	var externalAuthorize = false;
 
 	var failedLoginAttemptCount = 0;
 
@@ -115,6 +115,12 @@
 		// Disable / enable inputs as required, to ensure all and only appropriate inputs are submitted
 		$forgotPasswordInputs.prop('disabled', !switchToCreate);
 		$checkInput.prop('disabled', switchToCreate);
+	}
+
+	function toggleAuthorizeScreen() {
+		$('#displayName').text(display_name);
+		$loginForm.hide();
+		$authorizeForm.show();
 	}
 
 	function displayClientError(errorMessage) {
@@ -207,6 +213,11 @@
 		return false;
 	}
 
+	function doAuthorizeSubmit() {
+		window.location.href = return_url + '?token=' + localStorage['bms.xAuthToken'];
+		return false;
+	}
+
 	// Record whether media queries are supported in this browser as a class
 	if (!Modernizr.mq('only all')) {
 		$('html').addClass('no-mq');
@@ -236,6 +247,10 @@
 
 	$loginSubmit.on('click', function() {
 		return doFormSubmit();
+	});
+
+	$authorizeSubmit.on('click', function() {
+		return doAuthorizeSubmit();
 	});
 
 	// Hook up our fake (better looking) checkbox with it's real, submit-able counterpart
@@ -303,10 +318,7 @@
 		$loginSubmit.addClass('loading').delay(200);
 
 		// Continue with form submit - login is currently handled server side
-		if (externalAuthorize) {
-			window.location.href = return_url + '?token=' + token;
-
-		} else if (login) {
+		if (login) {
 			$.post($loginForm.data('validate-login-action'), $loginForm.serialize())
 				.done(function(data) {
 					clearErrors();
@@ -318,14 +330,10 @@
 					 *     localStorageServiceProvider.setPrefix('bms');
 					 */
 					localStorage['bms.xAuthToken'] = JSON.stringify(data);
-					// no login problems! submit
-					if (display_name &&  return_url) {
-						$('.login-form-control').hide();
-						$loginSubmit.text('Authorize');
-						$('#displayName').text(display_name + ' wants to access your BMS Account');
-						externalAuthorize = true;
-						token = data.token;
+					if (display_name && return_url) {
+						toggleAuthorizeScreen()
 					} else {
+						// no login problems! submit
 						loginFormRef.submit();
 					}
 				})

--- a/src/main/web/src/pages/login.html
+++ b/src/main/web/src/pages/login.html
@@ -30,10 +30,6 @@
 		applied to input elements in IE.
 	*/-->
 	<form th:action="@{/login}" th:attr="data-alt-action=@{/controller/auth/signup},data-forgot-password-action=@{/controller/auth/forgotPassword}, data-validate-login-action=@{/controller/auth/validateLogin}, data-reset-password-action=@{/controller/auth/sendResetEmail}" autocomplete="off" class="js-login-form login-form" method="post" novalidate="" th:classappend="${param.error != null} ? login-form-invalid">
-
-		<div>
-			<h1 align="center" id="displayName"></h1>
-		</div>
 		<!-- This is a dirty, necessary hack to avoid disgusting yellow inputs in Chrome. See http://stackoverflow.com/a/23467772/1712802 -->
 		<input class="js-fake-username" type="text" value="" style="display: none"/>
 		<input class="js-fake-password" type="password" value="" style="display: none"/>
@@ -104,6 +100,15 @@
 		<button class="js-login-submit login-submit login-flat-control login-clickable" formnovalidate="" type="button">
 			<span class="login-submit-label">Sign In</span>
 			<span class="throbber"></span>
+		</button>
+	</form>
+
+	<form id="authorize-form" class="login-form">
+		<div>
+			<h1><span id="displayName"></span> wants to access your BMS Account</h1>
+		</div>
+		<button class="js-authorize-submit login-submit login-flat-control login-clickable" formnovalidate="" type="button">
+			<span class="login-submit-label">Authorize</span>
 		</button>
 	</form>
 

--- a/src/main/web/src/sass/login.scss
+++ b/src/main/web/src/sass/login.scss
@@ -383,6 +383,14 @@ select {
 
 }
 
+#authorize-form {
+	display: none;
+
+	h1 {
+		text-align: center;
+	}
+}
+
 .login-mode-toggle {
 	margin-top: 1rem;
 	padding-bottom: 1rem;


### PR DESCRIPTION
The login screen uses css classes and css transitions to hide/show
sections (e.g. recover password). The initial approach for the authorize
window was to use the same form but instead of hiding elements with css
class, use jquery show/hide. For this reason a hidden element was
partially overlapping with the authorize button.
This new approach is to use a completely separate form, better for
separation of concerns. The css transitions is left as an improvement
for the future.

See also the improvement IBP-3605