### PR TITLE
IBP-3152 AddPrepDesignInDisplayDesignElements

### DIFF
--- a/src/main/java/org/generationcp/ibpworkbench/ui/breedingview/singlesiteanalysis/SingleSiteAnalysisDesignDetails.java
+++ b/src/main/java/org/generationcp/ibpworkbench/ui/breedingview/singlesiteanalysis/SingleSiteAnalysisDesignDetails.java
@@ -245,6 +245,8 @@ public class SingleSiteAnalysisDesignDetails extends VerticalLayout
 				this.displayIncompleteBlockDesignElements();
 			} else if (experimentDesignType.getId() == ExperimentDesignType.ROW_COL.getId()) {
 				this.displayRowColumnDesignElements();
+			} else if(experimentDesignType.getId() == ExperimentDesignType.P_REP.getId()){
+				this.displayPRepDesignElements();
 			} else if (experimentDesignType.getId() == ExperimentDesignType.AUGMENTED_RANDOMIZED_BLOCK.getId()) {
 				this.displayAugmentedDesignElements();
 			}

--- a/src/test/java/org/generationcp/ibpworkbench/ui/breedingview/singlesiteanalysis/SingleSiteAnalysisDesignDetailsTest.java
+++ b/src/test/java/org/generationcp/ibpworkbench/ui/breedingview/singlesiteanalysis/SingleSiteAnalysisDesignDetailsTest.java
@@ -284,6 +284,26 @@ public class SingleSiteAnalysisDesignDetailsTest {
 	}
 
 	@Test
+	public void testDesignTypePRepDesignInit() {
+		Mockito.when(this.experimentDesignService.getStudyExperimentDesignTypeTermId(this.input.getStudyId()))
+			.thenReturn(Optional.of(TermId.P_REP.getId()));
+
+		this.ssaDesignDetails.displayDesignElementsBasedOnDesignTypeOfTheStudy();
+		final List<Component> components = this.getComponentsListFromGridLayout();
+
+		Assert.assertTrue(components.contains(this.ssaDesignDetails.getLblBlocks()));
+		Assert.assertTrue(components.contains(this.ssaDesignDetails.getSelBlocks()));
+		Assert.assertFalse(components.contains(this.ssaDesignDetails.getLblReplicates()));
+		Assert.assertFalse(components.contains(this.ssaDesignDetails.getSelReplicates()));
+
+		final boolean spatialVariablesRequired = false;
+		this.verifyRowAndColumnFactorsArePresent(components, spatialVariablesRequired);
+		Assert.assertNull(
+			"Replicates factor is not needed in P-rep design, so replicates should be unselected (null)",
+			this.ssaDesignDetails.getSelReplicates().getValue());
+	}
+
+	@Test
 	public void testDesignTypeInvalid() {
 		this.ssaDesignDetails.displayDesignElementsBasedOnDesignTypeOfTheStudy();
 		Assert.assertNull(this.ssaDesignDetails.getSelDesignType().getValue());


### PR DESCRIPTION
Add prep design condition in initialization of SingleSiteAnalysisDesignDetails
Method modified: displayDesignElementsBasedOnDesignTypeOfTheStudy 
Display prep design is included in BreedingViewDesignTypeValueChangeListener.valueChange