### PR TITLE
Fix GET locations service and all places where it is used

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/shared/inventory/service/inventory.service.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/inventory/service/inventory.service.ts
@@ -25,7 +25,7 @@ export class InventoryService {
     queryLocation(requestLocation: any): Observable<Location[]> {
         const cropName = this.paramContext.cropName;
         const programUUID = this.paramContext.programUUID;
-        return this.http.get<Location[]>(SERVER_API_URL + `crops/${cropName}/programs/${programUUID}/locations`, {
+        return this.http.get<Location[]>(SERVER_API_URL + `crops/${cropName}/locations?programUUID=` + programUUID, {
             params: requestLocation,
             observe: 'response'
         }).pipe(map((res: HttpResponse<Location[]>) => res.body));

--- a/src/main/web/src/pages/BrAPI-Graphical-Queries/main.js
+++ b/src/main/web/src/pages/BrAPI-Graphical-Queries/main.js
@@ -23,8 +23,8 @@ $(document).ready(function () {
 });
 
 function loadLocations() {
-	var url = "/bmsapi/crops/" + getUrlParameter("cropName") + "/programs/" + getUrlParameter("programUUID")
-		+ "/locations?favoriteLocations=false&locationTypes" ;
+	var url = "/bmsapi/crops/" + getUrlParameter("cropName")
+		+ "/locations?programUUID=" + getUrlParameter("programUUID") + "&favoriteLocations=false&locationTypes";
 
 	return Promise.all([$.get({
 		dataType: "json",


### PR DESCRIPTION
Logic: If program is null, then only locations with no program assigned are retrieved. If program is not null, then locations with no program assigned plus locations assigned to the current program are retrieved.
IBP-4049