### PR TITLE
IBP-4114 Add "included gids" text also to item count

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-search.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-search.component.html
@@ -54,6 +54,8 @@
 			<div class="form-group form-inline">
 				<jhi-item-count-custom [page]="page" [total]="filteredItems" [itemsPerPage]="itemsPerPage"
 										   [limit]="5000"></jhi-item-count-custom>
+				<span style="padding-left: 5px;" class="font-italic" *ngIf="hasIncludedGids()"
+					  jhiTranslate="search-germplasm.included-gids"></span>
 				<span style="margin-left: 20px;">Selected:</span>
 				<span style="padding-left: 5px;" class="font-weight-bold">
 					<!-- includes gids not counted in filteredItems (e.g pedigree, group members)  -->


### PR DESCRIPTION
Add the same message available to selected count, but for item count:

![included-items](https://user-images.githubusercontent.com/19394293/98404744-e7e24800-2049-11eb-9dbe-9f96a2afea3b.png)

Without selecting items, the message will still be visible

![included-items-no-select](https://user-images.githubusercontent.com/19394293/98404709-d862ff00-2049-11eb-95c5-817dd04612c0.png)