### PR TITLE
IBP-4150 Small UI fix: Align "items per page" selector to the right

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-search.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-search.component.html
@@ -183,13 +183,15 @@
 										[maxSize]="5" [rotate]="true" (pageChange)="loadPage(page)"></ngb-pagination>
 					</div>
 					<div class="pagination-box pagination-box-right">
-						<label for="itemsPerPage" class="col-sm-4 control-label control-label-left">Items Per Page</label>
-						<select [(ngModel)]="itemsPerPage" class="form-control" id="itemsPerPage" [disabled]="isLoading" (change)="resetTable()" style="width:95px">
-							<option value="20">20</option>
-							<option value="50">50</option>
-							<option value="75">75</option>
-							<option value="100">100</option>
-						</select>
+						<div class="form-inline">
+							<label for="itemsPerPage" class="control-label control-label-left">Items Per Page</label>
+							<select [(ngModel)]="itemsPerPage" class="form-control ml-2" id="itemsPerPage" [disabled]="isLoading" (change)="resetTable()" style="width:95px">
+								<option value="20">20</option>
+								<option value="50">50</option>
+								<option value="75">75</option>
+								<option value="100">100</option>
+							</select>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Before
![items-per-page-old](https://user-images.githubusercontent.com/19394293/101081356-b5643600-3588-11eb-93d6-373e62af1bb8.png)

After
![items-per-page-new](https://user-images.githubusercontent.com/19394293/101081367-ba28ea00-3588-11eb-899c-beb9b1d190ca.png)

cc @darla-leafnode 