### PR TITLE
IBP-4144 Use WorkbenchMainView iframe name as link target

### DIFF
--- a/src/main/java/org/generationcp/browser/study/containers/StudyButtonRenderer.java
+++ b/src/main/java/org/generationcp/browser/study/containers/StudyButtonRenderer.java
@@ -25,7 +25,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 public class StudyButtonRenderer {
 
 	protected static final String[] URL_STUDY_TRIAL = {"/Fieldbook/TrialManager/openTrial/", "#/trialSettings"};
-	protected static final String PARENT_WINDOW = "_parent";
+	protected static final String WORKBENCHMAINVIEW_IFRAME_NAME = "PID_Sbrowser";
 	
 	@Autowired
 	private StudyPermissionValidator studyPermissionValidator;
@@ -45,7 +45,7 @@ public class StudyButtonRenderer {
 
 	public Button renderStudyButton() {
 		final ExternalResource urlToOpenStudy = getURLStudy();
-		Button studyButton = new LinkButton(urlToOpenStudy, study.getName(), PARENT_WINDOW);
+		Button studyButton = new LinkButton(urlToOpenStudy, study.getName(), WORKBENCHMAINVIEW_IFRAME_NAME);
 
 		try {
 			availableLinkToStudy(studyButton);

--- a/src/main/java/org/generationcp/ibpworkbench/germplasm/containers/ListsForGermplasmQuery.java
+++ b/src/main/java/org/generationcp/ibpworkbench/germplasm/containers/ListsForGermplasmQuery.java
@@ -48,7 +48,7 @@ public class ListsForGermplasmQuery implements Query {
 	public static final Object GERMPLASMLIST_DESCRIPTION = "description";
 
 	private static final String MANAGER_GERMPLASM = "/ibpworkbench/bm/list-manager?restartApplication&lists=";
-	private static final String PARENT_WINDOW = "_parent";
+	private static final String WORKBENCHMAINVIEW_IFRAME_NAME = "PID_Sbrowser";
 
 	private final GermplasmListManager dataManager;
 	private final Integer gid;
@@ -101,7 +101,7 @@ public class ListsForGermplasmQuery implements Query {
 				item.addItemProperty(ListsForGermplasmQuery.GERMPLASMLIST_ID, new ObjectProperty<String>(list.getId().toString()));
 
 				final ExternalResource urlToOpenGermplasmList = new ExternalResource(MANAGER_GERMPLASM + list.getId());
-				final LinkButton linkListButton = new LinkButton(urlToOpenGermplasmList, list.getName(), PARENT_WINDOW);
+				final LinkButton linkListButton = new LinkButton(urlToOpenGermplasmList, list.getName(), WORKBENCHMAINVIEW_IFRAME_NAME);
 				linkListButton.setDebugId("linkManageListButton");
 				linkListButton.addStyleName(BaseTheme.BUTTON_LINK);
 				try {

--- a/src/main/java/org/generationcp/ibpworkbench/sample/SampleInfoComponent.java
+++ b/src/main/java/org/generationcp/ibpworkbench/sample/SampleInfoComponent.java
@@ -50,7 +50,7 @@ public class SampleInfoComponent extends VerticalLayout implements InitializingB
 	private static final String URL_GENOTYPING_DATASET = "/GDMS/main/?restartApplication&datasetId=";
 
 	private static final String GENOTYPING_DATA = "genotyping dataset";
-	private static final String PARENT_WINDOW = "_parent";
+	private static final String WORKBENCHMAINVIEW_IFRAME_NAME = "PID_Sbrowser";
 
 	private static final String URL_STUDY_TRIAL = "/Fieldbook/TrialManager/openTrial/%s#/trialSettings";
 
@@ -139,7 +139,7 @@ public class SampleInfoComponent extends VerticalLayout implements InitializingB
 		for (final SampleDTO sample : sampleList) {
 
 			final ExternalResource urlToOpenStudy = getURLStudy(sample.getStudyId(), authParams);
-			final LinkButton linkStudyButton = new LinkButton(urlToOpenStudy, sample.getStudyName(), PARENT_WINDOW);
+			final LinkButton linkStudyButton = new LinkButton(urlToOpenStudy, sample.getStudyName(), WORKBENCHMAINVIEW_IFRAME_NAME);
 
 			try {
 				availableLinkToStudy(linkStudyButton);
@@ -155,7 +155,8 @@ public class SampleInfoComponent extends VerticalLayout implements InitializingB
 			for (final SampleDTO.Dataset dataset : sample.getDatasets()) {
 				final ExternalResource urlToOpenGenotypingData =
 					new ExternalResource(URL_GENOTYPING_DATASET + dataset.getDatasetId() + authParams);
-				final LinkButton linkGenotypingDataButton = new LinkButton(urlToOpenGenotypingData, dataset.getName(), PARENT_WINDOW);
+				final LinkButton linkGenotypingDataButton = new LinkButton(urlToOpenGenotypingData, dataset.getName(),
+					WORKBENCHMAINVIEW_IFRAME_NAME);
 				linkGenotypingDataButton.setDebugId("linkGenotypingDataButton");
 				linkGenotypingDataButton.addStyleName(BaseTheme.BUTTON_LINK);
 				horizontalLayoutForDatasetButton.addComponent(linkGenotypingDataButton);


### PR DESCRIPTION
Allows navigation from nested iframes (e.g germplasm details modal
inside germplasm selector modal) to the right parent ifram (which is not
_top).