### PR TITLE
 IBP-4393 Workaround Save List after Hibernate 4 migration

### DIFF
--- a/src/main/java/org/generationcp/breeding/manager/listmanager/listeners/SaveListButtonClickListener.java
+++ b/src/main/java/org/generationcp/breeding/manager/listmanager/listeners/SaveListButtonClickListener.java
@@ -118,7 +118,24 @@ public class SaveListButtonClickListener implements Button.ClickListener, Initia
 					listToSave.setUserId(SaveListButtonClickListener.this.contextUtil.getCurrentWorkbenchUserId());
 
 					final Integer listId = SaveListButtonClickListener.this.germplasmListManager.addGermplasmList(listToSave);
+					listToSave.setId(listId);
 
+					if (!listEntries.isEmpty()) {
+						SaveListButtonClickListener.this.setNeededValuesForNewListEntries(listToSave, listEntries);
+
+						if (!SaveListButtonClickListener.this.saveNewListEntries(listEntries)) {
+							return;
+						}
+
+						SaveListButtonClickListener.this.saveListDataColumns(listToSave);
+					}
+
+					/**
+					 * TODO Investigate IBP-4393 further
+					 *  After Migration to Hibernate 4 (IBP-3298), getGermplasmListById causes a lock and saveNewListEntries times out
+					 *  This doesn't happen if saving to Program List
+					 *  Move getById after saveNewListEntries as a workaround
+					 */
 					if (listId != null) {
 						final GermplasmList listSaved = SaveListButtonClickListener.this.germplasmListManager.getGermplasmListById(listId);
 						currentlySavedList = listSaved;
@@ -134,15 +151,7 @@ public class SaveListButtonClickListener implements Button.ClickListener, Initia
 					}
 
 					if (!listEntries.isEmpty()) {
-						SaveListButtonClickListener.this.setNeededValuesForNewListEntries(currentlySavedList, listEntries);
-
-						if (!SaveListButtonClickListener.this.saveNewListEntries(listEntries)) {
-							return;
-						}
-
 						SaveListButtonClickListener.this.updateListDataTableContent(currentlySavedList);
-
-						SaveListButtonClickListener.this.saveListDataColumns(listToSave);
 					}
 
 				} else if (currentlySavedList != null) {

--- a/src/main/java/org/generationcp/breeding/manager/listmanager/listeners/SaveListButtonClickListener.java
+++ b/src/main/java/org/generationcp/breeding/manager/listmanager/listeners/SaveListButtonClickListener.java
@@ -117,10 +117,10 @@ public class SaveListButtonClickListener implements Button.ClickListener, Initia
 
 					listToSave.setUserId(SaveListButtonClickListener.this.contextUtil.getCurrentWorkbenchUserId());
 
-					final Integer listId = SaveListButtonClickListener.this.germplasmListManager.addGermplasmList(listToSave);
-					listToSave.setId(listId);
+					SaveListButtonClickListener.this.germplasmListManager.addGermplasmList(listToSave);
 
 					if (!listEntries.isEmpty()) {
+
 						SaveListButtonClickListener.this.setNeededValuesForNewListEntries(listToSave, listEntries);
 
 						if (!SaveListButtonClickListener.this.saveNewListEntries(listEntries)) {
@@ -133,26 +133,26 @@ public class SaveListButtonClickListener implements Button.ClickListener, Initia
 					/**
 					 * TODO Investigate IBP-4393 further
 					 *  After Migration to Hibernate 4 (IBP-3298), getGermplasmListById causes a lock and saveNewListEntries times out
-					 *  This doesn't happen if saving to Program List
-					 *  Move getById after saveNewListEntries as a workaround
+					 *  GetByID was not required anyway. Please do not modify this code without properly testing all options in Germplasm List
 					 */
-					if (listId != null) {
-						final GermplasmList listSaved = SaveListButtonClickListener.this.germplasmListManager.getGermplasmListById(listId);
-						currentlySavedList = listSaved;
-						SaveListButtonClickListener.this.source.setCurrentlySavedGermplasmList(listSaved);
+					if (listToSave.getId() != null) {
+						currentlySavedList = listToSave;
+
+						if (!listEntries.isEmpty()) {
+							SaveListButtonClickListener.this.updateListDataTableContent(currentlySavedList);
+						}
+
+						SaveListButtonClickListener.this.source.setCurrentlySavedGermplasmList(listToSave);
 
 						SaveListButtonClickListener.this.source.setHasUnsavedChanges(false);
 
-						SaveListButtonClickListener.this.source.getSource().getListSelectionComponent().showNodeOnTree(listId);
+						SaveListButtonClickListener.this.source.getSource().getListSelectionComponent().showNodeOnTree(listToSave.getId());
 
 					} else {
 						SaveListButtonClickListener.this.showErrorOnSavingGermplasmList(showMessages);
 						return;
 					}
 
-					if (!listEntries.isEmpty()) {
-						SaveListButtonClickListener.this.updateListDataTableContent(currentlySavedList);
-					}
 
 				} else if (currentlySavedList != null) {
 

--- a/src/test/java/org/generationcp/breeding/manager/listmanager/listeners/SaveListButtonClickListenerTest.java
+++ b/src/test/java/org/generationcp/breeding/manager/listmanager/listeners/SaveListButtonClickListenerTest.java
@@ -36,6 +36,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.Mockito.doAnswer;
+
 public class SaveListButtonClickListenerTest {
 
 	private SaveListButtonClickListener saveListener;
@@ -164,7 +166,11 @@ public class SaveListButtonClickListenerTest {
 		Mockito.when(this.source.getCurrentlySetGermplasmListInfo()).thenReturn(this.germplasmList);
 		Mockito.when(this.source.getBuildNewListDropHandler()).thenReturn(buildNewListDropHandler);
 		Mockito.when(this.source.saveListAction()).thenReturn(false);
-		Mockito.when(this.dataManager.addGermplasmList(this.germplasmList)).thenReturn(1);
+		doAnswer(invocation -> {
+			Object[] args = invocation.getArguments();
+			((GermplasmList) args[0]).setId(1);
+			return null;
+		}).when(this.dataManager).addGermplasmList(this.germplasmList);
 		Mockito.when(this.dataManager.getGermplasmListById(Mockito.isA(Integer.class))).thenReturn(currentlySavedGermplasmList);
 
 		this.saveListener.doSaveAction(true, true);
@@ -190,8 +196,11 @@ public class SaveListButtonClickListenerTest {
 		final GermplasmListData germplasmListData = ListInventoryDataInitializer.createGermplasmListData(1);
 		Mockito.when(this.source.getListEntriesFromTable()).thenReturn(Lists.newArrayList(germplasmListData));
 
-		Mockito.when(this.dataManager.addGermplasmList(this.germplasmList)).thenReturn(1);
-		Mockito.when(this.dataManager.getGermplasmListById(Mockito.isA(Integer.class))).thenReturn(currentlySavedGermplasmList);
+		doAnswer(invocation -> {
+			Object[] args = invocation.getArguments();
+			((GermplasmList) args[0]).setId(1);
+			return null;
+		}).when(this.dataManager).addGermplasmList(this.germplasmList);
 
 		final List<Integer> listDataIds = Lists.newArrayList();
 		listDataIds.add(germplasmListData.getId());


### PR DESCRIPTION
After Migration to Hibernate 4 (IBP-3298), getGermplasmListById causes a lock and saveNewListEntries times out
This doesn't happen if saving to Program List
Move getById after saveNewListEntries as a workaround