### PR TITLE
IBP-4421-SetUserProgramInfo

### DIFF
--- a/src/main/java/org/generationcp/ibpworkbench/controller/UserProgramController.java
+++ b/src/main/java/org/generationcp/ibpworkbench/controller/UserProgramController.java
@@ -26,8 +26,6 @@ public class UserProgramController {
     @Resource
     private WorkbenchDataManager workbenchDataManager;
 
-    @Resource
-    private UserService userService;
 
     @Resource
     private AuthorizationService authorizationService;
@@ -42,26 +40,9 @@ public class UserProgramController {
             org.generationcp.commons.util.ContextUtil.setContextInfo(this.request,
                     this.contextUtil.getCurrentWorkbenchUserId(), project.getProjectId(), null);
 
-            this.updateProjectLastOpenedDate(project);
-
             this.authorizationService.reloadAuthorities(project);
         }
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    /**
-     * Updates Project last Opened Date and User's last opened Project
-     * @param project - Opened / Selected project
-     */
-    private void updateProjectLastOpenedDate(final Project project) {
-        ProjectUserInfo pui = this.userService.getProjectUserInfoByProjectIdAndUserId(project.getProjectId(), this.contextUtil.getCurrentWorkbenchUserId());
-        if (pui == null) {
-            pui = new ProjectUserInfo(project, this.contextUtil.getCurrentWorkbenchUser());
-        }
-        pui.setLastOpenDate(new Date());
-        this.userService.saveOrUpdateProjectUserInfo(pui);
-
-        project.setLastOpenDate(new Date());
-        this.workbenchDataManager.saveOrUpdateProject(project);
-    }
 }

--- a/src/main/java/org/generationcp/ibpworkbench/controller/UserProgramController.java
+++ b/src/main/java/org/generationcp/ibpworkbench/controller/UserProgramController.java
@@ -1,0 +1,67 @@
+package org.generationcp.ibpworkbench.controller;
+
+import org.generationcp.commons.security.AuthorizationService;
+import org.generationcp.commons.spring.util.ContextUtil;
+import org.generationcp.middleware.manager.api.WorkbenchDataManager;
+import org.generationcp.middleware.pojos.workbench.Project;
+import org.generationcp.middleware.pojos.workbench.ProjectUserInfo;
+import org.generationcp.middleware.service.api.user.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
+
+@Controller
+@RequestMapping(UserProgramController.URL)
+public class UserProgramController {
+    public static final String URL = "/userProgramController/";
+
+    @Resource
+    private ContextUtil contextUtil;
+
+    @Resource
+    private WorkbenchDataManager workbenchDataManager;
+
+    @Resource
+    private UserService userService;
+
+    @Resource
+    private AuthorizationService authorizationService;
+
+    @Resource
+    private HttpServletRequest request;
+
+    @RequestMapping(value = "/userProgramInfo", method = RequestMethod.POST)
+    public ResponseEntity<String> setUserProgramInfo(@RequestBody final String programUUID) {
+        final Project project = this.workbenchDataManager.getProjectByUuid(programUUID);
+        if (project != null) {
+            org.generationcp.commons.util.ContextUtil.setContextInfo(this.request,
+                    this.contextUtil.getCurrentWorkbenchUserId(), project.getProjectId(), null);
+
+            this.updateProjectLastOpenedDate(project);
+
+            this.authorizationService.reloadAuthorities(project);
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    /**
+     * Updates Project last Opened Date and User's last opened Project
+     * @param project - Opened / Selected project
+     */
+    private void updateProjectLastOpenedDate(final Project project) {
+        ProjectUserInfo pui = this.userService.getProjectUserInfoByProjectIdAndUserId(project.getProjectId(), this.contextUtil.getCurrentWorkbenchUserId());
+        if (pui == null) {
+            pui = new ProjectUserInfo(project, this.contextUtil.getCurrentWorkbenchUser());
+        }
+        pui.setLastOpenDate(new Date());
+        this.userService.saveOrUpdateProjectUserInfo(pui);
+
+        project.setLastOpenDate(new Date());
+        this.workbenchDataManager.saveOrUpdateProject(project);
+    }
+}

--- a/src/main/jhipster/src/main/webapp/app/app.constants.ts
+++ b/src/main/jhipster/src/main/webapp/app/app.constants.ts
@@ -9,6 +9,7 @@ export const BUILD_TIMESTAMP = process.env.BUILD_TIMESTAMP;
 export const GERMPLASM_BROWSER_DEFAULT_URL = '/ibpworkbench/maingpsb/germplasm-';
 export const BREEDING_METHODS_BROWSER_DEFAULT_URL = '/ibpworkbench/content/ProgramMethods';
 export const MAX_PAGE_SIZE = process.env.MAX_PAGE_SIZE;
+export const USER_PROGRAM_INFO = '/ibpworkbench/controller/userProgramController/userProgramInfo';
 
 // HELP
 export const HELP_BASE_URL = '/ibpworkbench/controller/help/getUrl/';

--- a/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
@@ -14,6 +14,7 @@ import { LoginService } from '../shared/login/login.service';
 import { HELP_NAVIGATION_ASK_FOR_SUPPORT, HELP_NAVIGATION_BAR_ABOUT_BMS, VERSION } from '../app.constants';
 import { HelpService } from '../shared/service/help.service';
 import { ADD_PROGRAM_PERMISSION, SITE_ADMIN_PERMISSIONS } from '../shared/auth/permissions';
+import { UserProgramInfoService } from '../shared/service/user-program-info.service';
 
 @Component({
     selector: 'jhi-navbar',
@@ -53,7 +54,8 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         private toolService: ToolService,
         private jhiAlertService: JhiAlertService,
         private loginService: LoginService,
-        private helpService: HelpService
+        private helpService: HelpService,
+        private userProgramInfoService: UserProgramInfoService
     ) {
         this.version = VERSION ? `BMS ${VERSION}` : '';
         this.principal.identity().then((identity) => {
@@ -128,30 +130,11 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         }
         if (event.data.programSelected) {
             const program = event.data.programSelected;
-
-            this.toolService.getTools(program.crop, program.uniqueID)
-                .subscribe(
-                    (res: HttpResponse<Tool[]>) => {
-                        if (!(res.body && res.body.length)) {
-                            this.jhiAlertService.error('error.no.tool.available');
-                            return;
-                        }
-
-                        this.program = program;
-                        localStorage['selectedProjectId'] = this.program.id;
-                        localStorage['loggedInUserId'] = this.user.userId;
-                        localStorage['cropName'] = this.program.crop;
-                        localStorage['programUUID'] = this.program.uniqueID;
-
-                        this.dataSource.data = res.body.map((response: Tool) => this.toNode(response));
-
-                        const firstNode = this.treeControl.dataNodes[0];
-                        this.treeControl.expand(firstNode);
-
-                        this.openTool(this.treeControl.getDescendants(firstNode)[0].link);
-                    },
-                    (res: HttpErrorResponse) => this.onError(res)
-                );
+            this.userProgramInfoService.setSelectedProgram(program.uniqueID).toPromise().then(() => {
+                this.getTools(program);
+            }).catch((error) => {
+                this.onError(error);
+            });
         } else if (event.data.programUpdated && this.program) {
             this.program.name = event.data.programUpdated.name;
         } else if (event.data.programDeleted) {
@@ -198,7 +181,9 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         if (!helpLink || !helpLink.length) {
             return await this.helpService.getHelpLink(key).toPromise().then((response) => {
                 return response.body;
-            }).catch((error) => {});
+            }).catch((error) => {
+                this.onError(error);
+            });
         }
     }
 
@@ -214,6 +199,31 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         }
     }
 
+    getTools(program) {
+        this.toolService.getTools(program.crop, program.uniqueID)
+            .subscribe(
+                (res: HttpResponse<Tool[]>) => {
+                    if (!(res.body && res.body.length)) {
+                        this.jhiAlertService.error('error.no.tool.available');
+                        return;
+                    }
+
+                    this.program = program;
+                    localStorage['selectedProjectId'] = this.program.id;
+                    localStorage['loggedInUserId'] = this.user.userId;
+                    localStorage['cropName'] = this.program.crop;
+                    localStorage['programUUID'] = this.program.uniqueID;
+
+                    this.dataSource.data = res.body.map((response: Tool) => this.toNode(response));
+
+                    const firstNode = this.treeControl.dataNodes[0];
+                    this.treeControl.expand(firstNode);
+
+                    this.openTool(this.treeControl.getDescendants(firstNode)[0].link);
+                },
+                (res: HttpErrorResponse) => this.onError(res)
+            );
+    }
 }
 
 interface Node {

--- a/src/main/jhipster/src/main/webapp/app/shared/service/user-program-info.service.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/service/user-program-info.service.ts
@@ -1,0 +1,14 @@
+import { Injectable, Inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { USER_PROGRAM_INFO } from '../../app.constants';
+import { Observable } from 'rxjs';
+@Injectable()
+export class UserProgramInfoService {
+
+    constructor(@Inject(HttpClient) private http: HttpClient) {
+    }
+
+    setSelectedProgram(programUUID: string): Observable<any> {
+        return this.http.post(USER_PROGRAM_INFO, programUUID, {responseType: 'text'});
+    }
+}

--- a/src/main/jhipster/src/main/webapp/app/shared/shared.module.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/shared.module.ts
@@ -55,6 +55,7 @@ import { SampleListCreationComponent } from './list-creation/sample-list-creatio
 import { KeySequenceRegisterService } from './key-sequence-register/service/key-sequence-register.service';
 import { ProgramService } from './program/service/program.service';
 import { ToolService } from './tool/service/tool.service';
+import { UserProgramInfoService } from './service/user-program-info.service';
 
 @NgModule({
     imports: [
@@ -119,6 +120,7 @@ import { ToolService } from './tool/service/tool.service';
         AlertService,
         ToolService,
         KeySequenceRegisterService,
+        UserProgramInfoService,
         /*
          * Workaround to reuse modal content outside ngb modals
          * https://github.com/ng-bootstrap/ng-bootstrap/issues/1755#issuecomment-344088034


### PR DESCRIPTION
Hi @clarysabel , @nahuel-soldevilla , @lik-83 
cc: @darla-leafnode @abatac 
Please review approach below: 

Comparing to version 17.0, when program is launched there are processes such as: 
1. Set ContextInfo (CurrentLoggedIn and ProjectId) 
2. Update user's last opened project and project opened date  
3. Reload authorities (By Project) 

To Fix issue: IBP-4421, I created a new endpoint to set selectedProgramId when user opened a program. In this endpoint I applied the steps above to set properly the permission of user.

1. **Set Context Info** - Attributes cropName and currentProgramId values are acquired from ContextUtil, currently it is not set therefore no permission is returned when opened a project. This variable are used by account.service to get user's permission. 
2. **Update workbench_project and workbench_project_user_info last opened date** - Currently this tables are not updated when user selected a program
3. **Reload authorities** - Upon successful logged permissions are set through WorkbenchUserDetailsService.loadUserByUsername, if cropName or programId is null (since user first loggedin), no permission will be returned. We need to reload authorities based on user's selected program. Affected screens are vaadin pages (GermplasmLists). _Intermittently occurred in Browse study_

Updates: 
New endpoint for setting user's selected program
This endpoint will be called before acquiring available tools for user
When user program info is provided, system will reload authorities (roles) for user's selected project
Project last opened date and user's last opened project will be updated.