### PR TITLE
IBP-4416 / IBP-4484 Upgrade podam dependency, fix docker build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,8 @@
 		<dependency>
 			<groupId>uk.co.jemos.podam</groupId>
 			<artifactId>podam</artifactId>
-			<version>2.3.5.RELEASE</version>
+			<version>5.4.1.RELEASE</version>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.mortbay.jetty</groupId>

--- a/src/main/java/org/generationcp/ibpworkbench/ui/programlocations/LocationViewModel.java
+++ b/src/main/java/org/generationcp/ibpworkbench/ui/programlocations/LocationViewModel.java
@@ -1,8 +1,6 @@
 package org.generationcp.ibpworkbench.ui.programlocations;
 
 import org.generationcp.middleware.pojos.BeanFormState;
-import uk.co.jemos.podam.api.PodamFactory;
-import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +35,6 @@ public class LocationViewModel implements BeanFormState {
 	private Boolean lDefault;
 
 	public LocationViewModel() {
-		// for unit testing only
 	}
 
 	public Integer getLtype() {
@@ -110,18 +107,6 @@ public class LocationViewModel implements BeanFormState {
 
 	public void setAltitude(final Double altitude) {
 		this.altitude = altitude;
-	}
-
-	public static List<LocationViewModel> generateRandomData(final int itemCount) {
-		final List<LocationViewModel> list = new ArrayList<>();
-
-		final PodamFactory factory = new PodamFactoryImpl();
-
-		for (int i = 0; i < itemCount; i++) {
-			list.add(factory.manufacturePojo(LocationViewModel.class));
-		}
-
-		return list;
 	}
 
 	@Override


### PR DESCRIPTION
Hibernate 4 (IBP-3298) appears to be using loglevel TRACE internally.
When running ibpworkbench.war before anything else (as it happens in the
 docker build), the error:
Caused by: java.lang.NoSuchFieldError: TRACE
is thrown by
org.hibernate.cfg.Configuration.configure(Configuration.java:2053)
hibernate-core-4.2.21.Final.jar:4.2.21.Final

The podam library used in Workbench was version 2.3.5.RELEASE, and it
seems it had the dependency log4j:log4j:jar:1.2.8:compile
which doesn't support this loglevel.

Upgrading podam removes the log4j dependency and fixes the issue.
Remove PodamFactory which is not available anymore and is not actually
used in LocationViewModel