### PR TITLE
IBP-4991: Ignore blank column headers on import germplasm

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import.component.ts
@@ -128,7 +128,7 @@ export class GermplasmImportComponent implements OnInit {
         });
 
         const errorMessage: string[] = [];
-        this.validateHeader(this.rawData[0], errorMessage);
+        this.validateHeader(headers, errorMessage);
         this.validateData(errorMessage);
 
         if (errorMessage.length !== 0) {
@@ -157,6 +157,9 @@ export class GermplasmImportComponent implements OnInit {
     }
 
     private validateHeader(fileHeader: string[], errorMessage: string[]) {
+    	//ignore empty column headers
+    	fileHeader = fileHeader.filter((header) => !!header);
+
         this.codes = {};
         Object.keys(fileHeader
             // get duplicates

--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import.component.ts
@@ -157,9 +157,8 @@ export class GermplasmImportComponent implements OnInit {
     }
 
     private validateHeader(fileHeader: string[], errorMessage: string[]) {
-    	//ignore empty column headers
-    	fileHeader = fileHeader.filter((header) => !!header);
-
+        // Ignore empty column headers
+        fileHeader = fileHeader.filter((header) => !!header);
         this.codes = {};
         Object.keys(fileHeader
             // get duplicates


### PR DESCRIPTION
- ignore blank columns on header validation to prevent duplicated column error