### PR TITLE
IBP-5102: Refactor: skip single matches in germplasm import

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import-matches.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import-matches.component.html
@@ -11,8 +11,7 @@
 		<div class="row mb-sm-3">
 			<div class="col">
 				<span jhiTranslate="germplasm.import.matches.matches.were.found" [translateValues]="{entryNo: entryNo, matchNumber: matchNumber, unassignedCount: unassignedCount}"></span>
-				<span *ngIf="!!puiMatch" jhiTranslate="germplasm.import.matches.with.pui.match" [translateValues]="{pui: puiMatch.germplasmPUI}"></span>
-				<span *ngIf="!puiMatch" jhiTranslate="germplasm.import.matches.click.on.an.entry"></span>
+				<span jhiTranslate="germplasm.import.matches.click.on.an.entry"></span>
 			</div>
 		</div>
 		<div class="row">
@@ -29,9 +28,8 @@
 						</thead>
 						<tbody>
 						<tr [@tableAnimation] *ngFor="let germplasm of matches | slice: (page-1) * pageSize : page * pageSize"
-							[class.selected]="selectMatchesResult[dataRow[HEADERS.ENTRY_NO]] == germplasm.gid || puiMatch?.gid == germplasm.gid"
-							[class.selectable]="!puiMatch"
-							(click)="!puiMatch && onSelectMatch(germplasm)">
+							[class.selected]="selectMatchesResult[dataRow[HEADERS.ENTRY_NO]] == germplasm.gid"
+							(click)="onSelectMatch(germplasm)">
 							<td><a [routerLink]="['/', { outlets: { popup: 'germplasm-details-dialog/' + germplasm.gid } }]" [queryParams]="{designation: germplasm.preferredName}">{{germplasm.gid}}</a></td>
 							<td><a [routerLink]="['/', { outlets: { popup: 'germplasm-details-dialog/' + germplasm.gid } }]" [queryParams]="{designation: germplasm.preferredName}">{{germplasm.preferredName}}</a></td>
 							<td><span *ngFor="let name of germplasm.names; let last = last">{{name.name}}<span *ngIf="!last">, </span></span></td>
@@ -65,7 +63,7 @@
 			<div class="col">
 				<div class="form-check form-check-inline">
 					<input type="checkbox" class="form-check-input" name="ignoreMatch" id="ignoreMatch"
-						   [(ngModel)]="isIgnoreMatch" [disabled]="isIgnoreAllRemaining || !!puiMatch"
+						   [(ngModel)]="isIgnoreMatch" [disabled]="isIgnoreAllRemaining"
 						   (change)="onIgnoreMatch()">
 					<label class="form-check-label" for="ignoreMatch" jhiTranslate="germplasm.import.matches.ignore.match">
 					</label>
@@ -76,7 +74,7 @@
 			<div class="col">
 				<div class="form-check form-check-inline">
 					<input type="checkbox" class="form-check-input" name="ignoreAllRemaining" id="ignoreAllRemaining"
-						   [(ngModel)]="isIgnoreAllRemaining" [disabled]="!!puiMatch"
+						   [(ngModel)]="isIgnoreAllRemaining"
 						   (change)="onIgnoreAllRemaining()">
 					<label class="form-check-label" for="ignoreAllRemaining" jhiTranslate="germplasm.import.matches.ignore.all.remaining">
 					</label>
@@ -94,7 +92,7 @@
 			(click)="back()">
 		<span jhiTranslate="back"></span>
 	</button>
-	<button (click)="next()" class="btn btn-primary" [disabled]="!(isIgnoreAllRemaining || isIgnoreMatch || puiMatch || selectMatchesResult[dataRow[HEADERS.ENTRY_NO]])">
+	<button (click)="next()" class="btn btn-primary" [disabled]="!(isIgnoreAllRemaining || isIgnoreMatch || selectMatchesResult[dataRow[HEADERS.ENTRY_NO]])">
 		<span *ngIf="isFinish(); else nextButton" jhiTranslate="finish"></span>
 		<ng-template #nextButton><span jhiTranslate="next"></span></ng-template>
 	</button>

--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import-review.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import-review.component.html
@@ -19,9 +19,10 @@
 				<select class="form-control" id="showMatchesDropdown" name="showMatchesDropdown"
 						(change)="onShowMatchesOptionChange()"
 						[(ngModel)]="showMatchesOption" #showMatchesDropdown="ngModel">
-					<option [value]="SHOW_MATCHES_OPTIONS.ALL">All</option>
-					<option [value]="SHOW_MATCHES_OPTIONS.ONLY_MATCHES">With existing matches only</option>
-					<option [value]="SHOW_MATCHES_OPTIONS.NEW_RECORDS">New records only</option>
+					<option [value]="SHOW_MATCHES_OPTIONS.ALL" jhiTranslate="germplasm.import.review.show.matches.all"></option>
+					<option [value]="SHOW_MATCHES_OPTIONS.WITH_A_SINGLE_MATCH" jhiTranslate="germplasm.import.review.show.matches.single"></option>
+					<option [value]="SHOW_MATCHES_OPTIONS.WITH_MULTIPLE_MATCHES" jhiTranslate="germplasm.import.review.show.matches.multi"></option>
+					<option [value]="SHOW_MATCHES_OPTIONS.NEW_RECORDS" jhiTranslate="germplasm.import.review.show.matches.new"></option>
 				</select>
 			</div>
 			<div class="col-sm-5" *ngIf="size(columnNamesWithDupes)">

--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import-review.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/import/germplasm-import-review.component.ts
@@ -19,7 +19,7 @@ import { JhiEventManager } from 'ng-jhipster';
 import { LotService } from '../../shared/inventory/service/lot.service';
 import { LotImportRequest, LotImportRequestLotList } from '../../shared/inventory/model/lot-import-request';
 import { ModalConfirmComponent } from '../../shared/modal/modal-confirm.component';
-import { GermplasmImportMatchesComponent } from './germplasm-import-matches.component';
+import { GermplasmImportMatchesComponent, getRowMatches } from './germplasm-import-matches.component';
 import { GermplasmListEntry } from '../../shared/list-creation/model/germplasm-list';
 import { toUpper } from '../../shared/util/to-upper';
 import { NameType } from '../../shared/germplasm/model/name-type.model';
@@ -48,7 +48,8 @@ export class GermplasmImportReviewComponent implements OnInit {
     // Review table html section
 
     // rows from file/data that matches
-    dataMatches: any[] = [];
+    dataSingleMatches: any[] = [];
+    dataMultipleMatches: any[] = [];
     // rows from file/data that doesn't match
     newRecords: any[] = [];
     // table displayed in html
@@ -64,6 +65,7 @@ export class GermplasmImportReviewComponent implements OnInit {
 
     // matches from db
     matches: GermplasmDto[];
+    // matches by pui are treated specially because they can't be ignored
     matchesByPUI: { [key: string]: GermplasmDto; } = {};
     matchesByName: { [key: string]: GermplasmDto[]; } = {};
 
@@ -129,32 +131,29 @@ export class GermplasmImportReviewComponent implements OnInit {
 
             this.context.data.forEach((row) => {
                 const puiMatch = this.matchesByPUI[toUpper(row[HEADERS.PUI])];
-                const nameMatches = this.context.nametypesCopy.filter((nameType) => {
-                    return Boolean(this.matchesByName[toUpper(row[nameType.code])]);
-                });
+                const rowMatches = getRowMatches(row, this.context.nametypesCopy, this.matchesByName);
+
                 if (puiMatch) {
-                    this.dataMatches.push(row);
+                    this.dataSingleMatches.push(row);
                     row[HEADERS['GID MATCHES']] = puiMatch.gid;
-                } else if (nameMatches.length) {
-                    this.dataMatches.push(row);
-                    row[HEADERS['GID MATCHES']] = nameMatches
-                        .reduce((array, nameType) => array.concat(this.matchesByName[toUpper(row[nameType.code])].map((m) => m.gid)), [])
-                        // dedup
-                        .filter((gid, i, array) => array.indexOf(gid) === i)
-                        .join(', ');
+                } else if (rowMatches.length) {
+                    if (rowMatches.length > 1) {
+                        this.dataMultipleMatches.push(row);
+                    } else {
+                        this.dataSingleMatches.push(row);
+                    }
+
+                    row[HEADERS['GID MATCHES']] = rowMatches.map((m) => m.gid).join(', ');
 
                     const matchesByPrefName = this.matchesByName[toUpper(row[row[HEADERS['PREFERRED NAME']]])];
                     if (matchesByPrefName && matchesByPrefName.length === 1) {
-                        // noop - full auto-match still posible
+                        // noop - full auto-match still possible
                     } else if (matchesByPrefName && matchesByPrefName.length > 1) {
                         // more than one match by pref name
                         this.isFullAutomaticMatchNotPossible = true;
-                    } else if (nameMatches.length) {
+                    } else if (rowMatches.length > 1) {
                         /*
                          * Preferred name is new (no match), but other names have matches.
-                         * Even if it's only one match, the system will show the manual
-                         * selection process anyway, so that's it is clear we are not
-                         * using the preferred name.
                          */
                         this.isFullAutomaticMatchNotPossible = true;
                     }
@@ -162,7 +161,7 @@ export class GermplasmImportReviewComponent implements OnInit {
                     this.newRecords.push(row);
                 }
             });
-            this.rows = [...this.dataMatches, ...this.newRecords];
+            this.rows = this.getAllRows();
             this.columnNamesWithDupes = this.findDupesInNewRecords(this.newRecords);
         });
 
@@ -170,6 +169,11 @@ export class GermplasmImportReviewComponent implements OnInit {
             || row[HEADERS['STORAGE LOCATION ABBR']]
             || row[HEADERS['UNITS']]
             || row[HEADERS['AMOUNT']]);
+    }
+
+    private getAllRows() {
+        return [...this.dataSingleMatches, ...this.dataMultipleMatches, ...this.newRecords]
+            .sort(((a, b) => Number(a[HEADERS.ENTRY_NO]) > Number(b[HEADERS.ENTRY_NO]) ? 1 : -1));
     }
 
     private findDupesInNewRecords(newEntries: any[]) {
@@ -311,47 +315,56 @@ export class GermplasmImportReviewComponent implements OnInit {
     }
 
     private async processMatches(): Promise<boolean> {
-        const unassignedMatches = this.dataMatches;
-        this.selectMatchesResult = {};
+        let unassignedMatches = this.dataMultipleMatches;
 
-        if (unassignedMatches.length) {
-            if (this.creationOption === CREATION_OPTIONS.SELECT_EXISTING) {
-                if (this.isSelectMatchesAutomatically) {
-                    unassignedMatches.forEach((row) => {
-                        const puiMatch = this.matchesByPUI[toUpper(row[HEADERS.PUI])];
-                        if (!puiMatch) {
-                            const matches = this.matchesByName[toUpper(row[row[HEADERS['PREFERRED NAME']]])];
-                            if (matches && matches.length === 1) {
-                                this.selectMatchesResult[row[HEADERS.ENTRY_NO]] = matches[0].gid;
-                            }
-                        }
-                    });
-                }
-                /*
-                 * if 1) auto-matching didn't work:
-                 *      a) multiple gids for preferred name or..
-                 *      b) preferred name does not exist, but other names have matches
-                 *    2) auto-matching unchecked
-                 * -> open manual
-                 */
-                if (unassignedMatches.some((row) => !this.selectMatchesResult[row[HEADERS.ENTRY_NO]]
-                    && !this.matchesByPUI[toUpper(row[HEADERS.PUI])])) {
-
-                    const selectMatchesModalRef = this.modalService.open(GermplasmImportMatchesComponent as Component,
-                        { size: 'lg', backdrop: 'static' });
-                    selectMatchesModalRef.componentInstance.unassignedMatches = unassignedMatches;
-                    selectMatchesModalRef.componentInstance.matchesByName = this.matchesByName;
-                    selectMatchesModalRef.componentInstance.matchesByPUI = this.matchesByPUI;
-                    selectMatchesModalRef.componentInstance.selectMatchesResult = this.selectMatchesResult;
-                    try {
-                        await selectMatchesModalRef.result;
-                    } catch (rejected) {
-                        return false;
-                    }
-                }
-            } else if (this.creationOption === CREATION_OPTIONS.CREATE_NEW) {
-                this.selectMatchesResult = {};
+        /*
+         * Initialize matchesResult with auto-selected single matches.
+         * Considering it a match result simplifies other processes like "ignore and create new".
+         */
+        this.selectMatchesResult = this.dataSingleMatches.reduce((map, row) => {
+            if (this.matchesByPUI[toUpper(row[HEADERS.PUI])]) {
+                return map;
             }
+            const singleMatch = getRowMatches(row, this.context.nametypesCopy, this.matchesByName)[0];
+            map[row[HEADERS.ENTRY_NO]] = singleMatch.gid;
+            return map;
+        }, {});
+
+        if (this.creationOption === CREATION_OPTIONS.SELECT_EXISTING) {
+            if (this.isSelectMatchesAutomatically) {
+                unassignedMatches.forEach((row) => {
+                    const matches = this.matchesByName[toUpper(row[row[HEADERS['PREFERRED NAME']]])];
+                    if (matches && matches.length === 1) {
+                        this.selectMatchesResult[row[HEADERS.ENTRY_NO]] = matches[0].gid;
+                    }
+                });
+            }
+            /*
+             * if 1) auto-matching didn't work:
+             *      a) multiple gids for preferred name or..
+             *      b) preferred name does not exist, but other names have matches
+             *    2) auto-matching unchecked
+             * -> open manual
+             */
+            if (unassignedMatches.some((row) => !this.selectMatchesResult[row[HEADERS.ENTRY_NO]]
+                && !this.matchesByPUI[toUpper(row[HEADERS.PUI])])) {
+
+                // remove auto-matched rows so far by pref name
+                unassignedMatches = unassignedMatches.filter((row) => !this.selectMatchesResult[row[HEADERS.ENTRY_NO]]);
+
+                const selectMatchesModalRef = this.modalService.open(GermplasmImportMatchesComponent as Component,
+                    { size: 'lg', backdrop: 'static' });
+                selectMatchesModalRef.componentInstance.unassignedMatches = unassignedMatches;
+                selectMatchesModalRef.componentInstance.matchesByName = this.matchesByName;
+                selectMatchesModalRef.componentInstance.selectMatchesResult = this.selectMatchesResult;
+                try {
+                    await selectMatchesModalRef.result;
+                } catch (rejected) {
+                    return false;
+                }
+            }
+        } else if (this.creationOption === CREATION_OPTIONS.CREATE_NEW) {
+            this.selectMatchesResult = {};
         }
 
         return true;
@@ -359,9 +372,15 @@ export class GermplasmImportReviewComponent implements OnInit {
 
     private async showSummaryConfirmation() {
         const countMatchByPUI = this.context.data.filter((row) => this.matchesByPUI[toUpper(row[HEADERS.PUI])]).length,
-            countMatchByName = this.context.data.filter((row) => this.selectMatchesResult[row[HEADERS.ENTRY_NO]]).length,
+
+            // of the initial matches, how many were finally accepted
+            countMultiMatches = this.dataMultipleMatches.filter((row) => this.selectMatchesResult[row[HEADERS.ENTRY_NO]]).length,
+            countSingleMatches = this.dataSingleMatches.filter((row) => this.selectMatchesResult[row[HEADERS.ENTRY_NO]]).length,
+
             countNew = this.newRecords.length,
-            countIgnored = this.dataMatches.length - countMatchByName - countMatchByPUI;
+            countIgnored = this.dataMultipleMatches.length + this.dataSingleMatches.length
+                - countMultiMatches - countSingleMatches - countMatchByPUI;
+
         const messages = [];
         if (countNew) {
             messages.push(this.translateService.instant('germplasm.import.review.summary.new', { param: countNew }));
@@ -369,8 +388,11 @@ export class GermplasmImportReviewComponent implements OnInit {
         if (countIgnored) {
             messages.push(this.translateService.instant('germplasm.import.review.summary.ignored', { param: countIgnored }));
         }
-        if (countMatchByName) {
-            messages.push(this.translateService.instant('germplasm.import.review.summary.match.by.name', { param: countMatchByName }));
+        if (countMultiMatches) {
+            messages.push(this.translateService.instant('germplasm.import.review.summary.match.by.name.multi', { param: countMultiMatches }));
+        }
+        if (countSingleMatches) {
+            messages.push(this.translateService.instant('germplasm.import.review.summary.match.by.name.single', { param: countSingleMatches }));
         }
         if (countMatchByPUI) {
             messages.push(this.translateService.instant('germplasm.import.review.summary.match.by.pui', { param: countMatchByPUI }));
@@ -500,10 +522,13 @@ export class GermplasmImportReviewComponent implements OnInit {
     onShowMatchesOptionChange() {
         switch (this.showMatchesOption) {
             case SHOW_MATCHES_OPTIONS.ALL:
-                this.rows = [...this.dataMatches, ...this.newRecords];
+                this.rows = this.getAllRows();
                 break;
-            case SHOW_MATCHES_OPTIONS.ONLY_MATCHES:
-                this.rows = this.dataMatches;
+            case SHOW_MATCHES_OPTIONS.WITH_A_SINGLE_MATCH:
+                this.rows = this.dataSingleMatches;
+                break;
+            case SHOW_MATCHES_OPTIONS.WITH_MULTIPLE_MATCHES:
+                this.rows = this.dataMultipleMatches;
                 break;
             case SHOW_MATCHES_OPTIONS.NEW_RECORDS:
                 this.rows = this.newRecords;
@@ -514,7 +539,8 @@ export class GermplasmImportReviewComponent implements OnInit {
 
 enum SHOW_MATCHES_OPTIONS {
     ALL = 'ALL',
-    ONLY_MATCHES = 'ONLY_MATCHES',
+    WITH_A_SINGLE_MATCH = 'WITH_A_SINGLE_MATCH',
+    WITH_MULTIPLE_MATCHES = 'WITH_MULTIPLE_MATCHES',
     NEW_RECORDS = 'NEW_RECORDS'
 }
 

--- a/src/main/jhipster/src/main/webapp/i18n/en/germplasm-manager.json
+++ b/src/main/jhipster/src/main/webapp/i18n/en/germplasm-manager.json
@@ -189,6 +189,10 @@
             "review": {
                 "header": "Review",
                 "show.matches": "Show matches",
+                "show.matches.all": "All",
+                "show.matches.single": "With a single match",
+                "show.matches.multi": "With multiple matches",
+                "show.matches.new": "New records only",
                 "creation.options": "Creation options",
                 "select.existing": "Select existing germplasm whenever found",
                 "create.new": "Create new records",
@@ -200,7 +204,8 @@
                     "message": "<h4>Import summary:</h4><p>{{param}}</p>",
                     "new": "{{param}} entries have no matches <strong>(new records will be created)</strong>",
                     "ignored": "{{param}} entries with matches were ignored <strong>(new records will be created)</strong>",
-                    "match.by.name": "{{param}} entries with matches <b>by name</b> were selected (no records will be created)",
+                    "match.by.name.multi": "{{param}} entries with <b>multiple</b> matches <b>by name</b> were selected (no records will be created)",
+                    "match.by.name.single": "{{param}} entries with <b>single</b> matches <b>by name</b> were automatically selected (no records will be created)",
                     "match.by.pui": "{{param}} entries with matches <b>by PUI</b> were automatically selected (no records will be created)",
                     "inventory": "{{param}} lots will be created",
                     "progenitors": "{{param}} entries will be connected with progenitors"


### PR DESCRIPTION
- split rows into single and multi matches
- skip single matches completely from manual matching process

Other improvements:
- skip also auto-matches by preferred name from the manual matching process (if auto-mach checked)
- Removed disabled pui entries from manual matching process (pui matches  are included in the list of single matches)