### PR TITLE
IBP-5267: Import ENTRY_CODE updates. Make variable-matches agnostic

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import-review.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import-review.component.ts
@@ -175,7 +175,13 @@ export class GermplasmListImportReviewComponent implements OnInit {
 
         if (variables && variables.length) {
             const modalRef = this.modalService.open(GermplasmListVariableMatchesComponent as Component, { size: 'lg', backdrop: 'static' });
-            modalRef.componentInstance.isGermplasmListImport = true;
+            modalRef.result.then((variableMatchesResult) => {
+                if (variableMatchesResult) {
+                    this.modalService.open(GermplasmListImportReviewComponent as Component, { size: 'lg', backdrop: 'static' });
+                } else {
+                    this.modalService.open(GermplasmListImportComponent as Component, { size: 'lg', backdrop: 'static' });
+                }
+            });
         } else {
             this.modalService.open(GermplasmListImportComponent as Component, { size: 'lg', backdrop: 'static' });
         }

--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import-update.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import-update.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
 	<h4 class="modal-title font-weight-bold">
-		<span jhiTranslate="germplasm-list.import.variable.matches.update.header"></span>
+		<span jhiTranslate="germplasm-list.import-updates.header"></span>
 	</h4>
 	<button type="button" class="close" data-dismiss="modal" aria-hidden="true"
 			(click)="dismiss()">&times;

--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import-update.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import-update.component.ts
@@ -7,14 +7,16 @@ import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { GermplasmService } from '../../shared/germplasm/service/germplasm.service';
 import { VariableService } from '../../shared/ontology/service/variable.service';
 import { parseFile, saveFile } from '../../shared/util/file-utils';
-import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 import { formatErrorList } from '../../shared/alert/format-error-list';
 import { GermplasmListService } from '../../shared/germplasm-list/service/germplasm-list.service';
 import { GermplasmListImportContext } from './germplasm-list-import.context';
 import { VariableTypeEnum } from '../../shared/ontology/variable-type.enum';
 import { toUpper } from '../../shared/util/to-upper';
-import { VariableDetails } from '../../shared/ontology/model/variable-details';
 import { GermplasmListVariableMatchesComponent } from './germplasm-list-variable-matches.component';
+import { ListComponent } from '../list.component';
+import { JhiEventManager } from 'ng-jhipster';
+import { ModalConfirmComponent } from '../../shared/modal/modal-confirm.component';
 
 @Component({
     selector: 'jhi-germplasm-list-import-update',
@@ -46,6 +48,7 @@ export class GermplasmListImportUpdateComponent implements OnInit {
         private germplasmService: GermplasmService,
         private variableService: VariableService,
         private context: GermplasmListImportContext,
+        private eventManager: JhiEventManager,
         private germplasmListService: GermplasmListService
     ) {
     }
@@ -89,13 +92,74 @@ export class GermplasmListImportUpdateComponent implements OnInit {
             this.isLoading = false;
             if (valid) {
                 this.modal.close();
-                const modalRef = this.modalService.open(GermplasmListVariableMatchesComponent as Component, { size: 'lg', backdrop: 'static' });
-                modalRef.componentInstance.isGermplasmListImport = false;
+                if (this.hasVariables()) {
+                    const modalRef = this.modalService.open(GermplasmListVariableMatchesComponent as Component, { size: 'lg', backdrop: 'static' });
+                    modalRef.result.then((variableMatchesResult) => {
+                        if (variableMatchesResult) {
+                            this.save(variableMatchesResult);
+                        } else {
+                            this.modalService.open(GermplasmListImportUpdateComponent as Component, { size: 'lg', backdrop: 'static' });
+                        }
+                    });
+                } else {
+                    this.save({});
+                }
             }
         }, (res) => {
             this.isLoading = false;
             this.onError(res);
         });
+    }
+
+    async save(variableMatchesResult) {
+
+        const doContinue = await this.showSummaryConfirmation();
+        if (!doContinue) {
+            return;
+        }
+
+        this.isLoading = true;
+        const listId = Number(this.route.snapshot.queryParamMap.get('listId'));
+        const germplasmListGenerator = { id: listId, entries: [] };
+        for (const row of this.context.data) {
+            const entry = {
+                entryNo: row[HEADERS.ENTRY_NO],
+                // Temporary workaround to allow users to edit ENTRY_CODE
+                entryCode: row[HEADERS.ENTRY_CODE],
+                data: Object.keys(variableMatchesResult).reduce((map, variableName) => {
+                    if (row[variableName]) {
+                        map[variableMatchesResult[variableName]] = { value: row[variableName] };
+                    }
+                    return map;
+                }, {})
+            };
+            germplasmListGenerator.entries.push(entry);
+        }
+
+        this.germplasmListService.germplasmListUpdates(germplasmListGenerator).subscribe(
+            () => {
+                this.isLoading = false;
+                this.modal.close();
+                this.eventManager.broadcast({ name: listId + ListComponent.GERMPLASM_LIST_CHANGED });
+            },
+            (error) => {
+                this.isLoading = false;
+                this.onError(error);
+            }
+        );
+
+    }
+
+    private async showSummaryConfirmation() {
+        const confirmModalRef = this.modalService.open(ModalConfirmComponent as Component,
+            { windowClass: 'modal-medium', backdrop: 'static' });
+        confirmModalRef.componentInstance.message = this.translateService.instant('germplasm-list.import-updates.confirmation', {param: this.context.data.length});
+        try {
+            await confirmModalRef.result;
+        } catch (rejected) {
+            return false;
+        }
+        return true;
     }
 
     private async validateFile() {
@@ -124,9 +188,8 @@ export class GermplasmListImportUpdateComponent implements OnInit {
         }
 
         await this.processEntryDetailVariables();
-        const variables = [...this.context.newVariables, ...this.context.unknownVariableNames, ...this.context.variablesOfTheList]
 
-        if (!variables || !variables.length) {
+        if (!this.hasEntryCode() && this.hasVariables()) {
             this.alertService.error('germplasm-list.import.file.validation.entry.details.no.column');
             return false;
         }
@@ -218,6 +281,17 @@ export class GermplasmListImportUpdateComponent implements OnInit {
         }
     }
 
+    private hasEntryCode() {
+        return this.context.data.some((row) => row[HEADERS.ENTRY_CODE]);
+    }
+
+    private hasVariables() {
+        return [
+            ...this.context.newVariables,
+            ...this.context.unknownVariableNames,
+            ...this.context.variablesOfTheList
+        ].length;
+    }
 }
 
 @Component({
@@ -246,5 +320,6 @@ export class GermplasmListImportUpdatePopupComponent implements OnInit, OnDestro
 }
 
 export enum HEADERS {
-    'ENTRY_NO' = 'ENTRY_NO'
+    'ENTRY_NO' = 'ENTRY_NO',
+    'ENTRY_CODE' = 'ENTRY_CODE'
 }

--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-import.component.ts
@@ -89,7 +89,13 @@ export class GermplasmListImportComponent implements OnInit {
 
                 if (variables && variables.length) {
                     const modalRef = this.modalService.open(GermplasmListVariableMatchesComponent as Component, { size: 'lg', backdrop: 'static' });
-                    modalRef.componentInstance.isGermplasmListImport = true;
+                    modalRef.result.then((variableMatchesResult) => {
+                        if (variableMatchesResult) {
+                            this.modalService.open(GermplasmListImportReviewComponent as Component, { size: 'lg', backdrop: 'static' });
+                        } else {
+                            this.modalService.open(GermplasmListImportComponent as Component, { size: 'lg', backdrop: 'static' });
+                        }
+                    });
                 } else {
                     this.modalService.open(GermplasmListImportReviewComponent as Component, { size: 'lg', backdrop: 'static' });
                 }

--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-variable-matches.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-variable-matches.component.html
@@ -1,15 +1,13 @@
 <div class="modal-header">
 	<h4 class="modal-title font-weight-bold">
-		<span *ngIf="isGermplasmListImport" jhiTranslate="germplasm-list.import.header"></span>
-		<span *ngIf="!isGermplasmListImport" jhiTranslate="germplasm-list.import.variable.matches.update.header"></span>
-
+		<span jhiTranslate="germplasm-list.variable.matches.header"></span>
 	</h4>
 	<button type="button" class="close" data-dismiss="modal" aria-hidden="true"
 			(click)="dismiss()">&times;
 	</button>
 </div>
 <div class="modal-body">
-	<h3 jhiTranslate="germplasm-list.import.variable.matches.entry.details"></h3>
+	<h3 jhiTranslate="germplasm-list.variable.matches.entry.details"></h3>
 	<br/>
 	<div>
 		<div class="row">
@@ -17,9 +15,9 @@
 				<div class="table-responsive">
 					<table class="table table-striped table-bordered table-curved">
 						<thead>
-						<th jhiTranslate="germplasm-list.import.variable.matches.columns.name"></th>
-						<th jhiTranslate="germplasm-list.import.variable.matches.columns.description"></th>
-						<th jhiTranslate="germplasm-list.import.variable.matches.columns.status"></th>
+						<th jhiTranslate="germplasm-list.variable.matches.columns.name"></th>
+						<th jhiTranslate="germplasm-list.variable.matches.columns.description"></th>
+						<th jhiTranslate="germplasm-list.variable.matches.columns.status"></th>
 						</thead>
 						<tbody *ngIf="rows && rows.length else nodata">
 						<tr *ngFor="let variable of rows | slice: (page-1) * pageSize : page * pageSize">
@@ -84,11 +82,7 @@
 	<button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="back()">
 		<span jhiTranslate="back"></span>
 	</button>
-	<button *ngIf="!isGermplasmListImport" (click)="save()" class="btn btn-primary" [disabled]="isLoading">
-		<span *ngIf="isLoading" class="throbber throbber-btn"></span>
-		<span jhiTranslate="save"></span>
-	</button>
-	<button *ngIf="isGermplasmListImport" (click)="next()" class="btn btn-primary" [disabled]="isLoading">
+	<button (click)="next()" class="btn btn-primary" [disabled]="isLoading">
 		<span *ngIf="isLoading" class="throbber throbber-btn"></span>
 		<span jhiTranslate="next"></span>
 	</button>

--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-variable-matches.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/import/germplasm-list-variable-matches.component.ts
@@ -31,7 +31,6 @@ export class GermplasmListVariableMatchesComponent implements OnInit {
 
     rows = [];
     variableMatchesResult: any = {};
-    isGermplasmListImport: boolean;
 
     constructor(
         private route: ActivatedRoute,
@@ -91,54 +90,18 @@ export class GermplasmListVariableMatchesComponent implements OnInit {
 
     back() {
         this.modal.close();
-        if (this.isGermplasmListImport) {
-            this.modalService.open(GermplasmListImportComponent as Component, { size: 'lg', backdrop: 'static' });
-        } else {
-            this.modalService.open(GermplasmListImportUpdateComponent as Component, { size: 'lg', backdrop: 'static' });
-        }
     }
 
     dismiss() {
-        const confirmModalRef = this.modalService.open(ModalConfirmComponent as Component, { backdrop: 'static' });
-        confirmModalRef.componentInstance.message = this.translateService.instant('germplasm-list.import.cancel.confirm');
-        confirmModalRef.result.then(() => this.modal.dismiss());
+        this.modal.dismiss();
     }
 
     next() {
-        this.modal.close();
-        this.modalService.open(GermplasmListImportReviewComponent as Component, { size: 'lg', backdrop: 'static' });
+        this.modal.close(this.variableMatchesResult);
     }
 
     save() {
-        this.isLoading = true;
-        const keys = Object.keys(this.context.data[0]);
-        const listId = Number(this.route.snapshot.queryParamMap.get('listId'));
-        const germplasmListGenerator = { id: listId, entries: [] };
-        for (const row of this.context.data) {
-            const entry = {
-                entryNo: row[HEADERS.ENTRY_NO],
-                data: Object.keys(this.variableMatchesResult).reduce((map, variableName) => {
-                    if (row[variableName]) {
-                        map[this.variableMatchesResult[variableName]] = { value: row[variableName] };
-                    }
-                    return map;
-                }, {})
-            };
-            germplasmListGenerator.entries.push(entry);
-        }
-
-        this.germplasmListService.germplasmListUpdates(germplasmListGenerator).subscribe(
-            () => {
-                this.isLoading = false;
-                this.modal.close();
-                this.eventManager.broadcast({ name: listId + ListComponent.GERMPLASM_LIST_CHANGED });
-            },
-            (error) => {
-                this.isLoading = false;
-                this.onError(error);
-            }
-        );
-
+        this.modal.close(this.variableMatchesResult);
     }
 
     private onError(response: HttpErrorResponse) {
@@ -154,6 +117,8 @@ export class GermplasmListVariableMatchesComponent implements OnInit {
 
 export enum HEADERS {
     'ENTRY_NO' = 'ENTRY_NO',
+    // Temporary workaround to allow users to edit ENTRY_CODE
+    'ENTRY_CODE' = 'ENTRY_CODE',
     'ID' = 'ID',
     'NAME' = 'NAME',
     'DESCRIPTION' = 'DESCRIPTION'

--- a/src/main/jhipster/src/main/webapp/i18n/en/germplasm-list.json
+++ b/src/main/jhipster/src/main/webapp/i18n/en/germplasm-list.json
@@ -80,17 +80,6 @@
         },
         "import": {
             "header": "Import List",
-            "variable.matches": {
-                "update": {
-                    "header": "Import List Update"
-                },
-                "entry.details": "Entry Details",
-                "columns": {
-                    "name": "VARIABLE NAME",
-                    "description": "DESCRIPTION",
-                    "status": "STATUS"
-                }
-            },
             "file": {
                 "input.description": "Choose the file you would like to import in format: Excel",
                 "validation": {
@@ -137,6 +126,19 @@
             },
             "cancel.confirm": "Are you sure you want to quit the import process?",
             "success": "Germplasm imported successfully!"
+        },
+        "import-updates": {
+            "header": "Import List Update",
+            "confirmation": "You are going to import {{param}} entry updates. Proceed?"
+        },
+        "variable.matches": {
+            "header": "Variables",
+            "entry.details": "Entry Details",
+            "columns": {
+                "name": "VARIABLE NAME",
+                "description": "DESCRIPTION",
+                "status": "STATUS"
+            }
         }
     }
 }


### PR DESCRIPTION
Variable matches:
- Extract code related to import updates in variable matches component
 - Move it main import list updates component
 - resolve modal with matches result in next() or empty if back()
- Use a generic title
- Add confirmation modal in main import updates component as a last step
 mechanism, which also makes it possible to use agnostic next() button
 in variable matches.

Entry code:
- Import Entry code column
- Skip variable matches window if file not contains variable but
contains entry code.