### PR TITLE
IBP-5308: Graphical filtering: keep custom filter in datatables until reset

### DIFF
--- a/src/main/web/src/pages/BrAPI-Graphical-Queries/GraphicalFilter.js
+++ b/src/main/web/src/pages/BrAPI-Graphical-Queries/GraphicalFilter.js
@@ -54,6 +54,11 @@ function GraphicalFilter() {
 			gfilter.filteredData.length = 0;
 
 			var currentFilter = gfilter.root.getFilter();
+
+			// clear the previous custom filter
+			// we only add custom filters here, so this should be safe
+			$.fn.dataTableExt.afnFiltering.pop();
+
 			$.fn.dataTableExt.afnFiltering.push(function (_1, _2, dataIndex) {
 				var currentData = gfilter.data[dataIndex];
 				var applyFilter = currentFilter(currentData);
@@ -64,7 +69,6 @@ function GraphicalFilter() {
 				return applyFilter;
 			});
 			gfilter.results_table.draw();
-			$.fn.dataTableExt.afnFiltering.pop();
 		}
 		gfilter.redraw();
 	};


### PR DESCRIPTION
custom `dataTableExt.afnFiltering` was being removed immediately after
filtering, which means that any additional filter (or sort) coming from
the datatable itself will clear the custom filters from the graphical
component.
Move `$.fn.dataTableExt.afnFiltering.pop()` before `push()`, not only to
keep the filter after the first apply, but also to clear previous
filters on `redraw()`