### PR TITLE
IBP-5321: Germplasm Import: if automatic match not selected, no auto-select single matches

### DIFF
--- a/src/main/jhipster/src/main/webapp/i18n/en/germplasm-manager.json
+++ b/src/main/jhipster/src/main/webapp/i18n/en/germplasm-manager.json
@@ -206,7 +206,7 @@
                     "new": "{{param}} entries have no matches <strong>(new records will be created)</strong>",
                     "ignored": "{{param}} entries with matches were ignored <strong>(new records will be created)</strong>",
                     "match.by.name.multi": "{{param}} entries with <b>multiple</b> matches <b>by name</b> were selected (no records will be created)",
-                    "match.by.name.single": "{{param}} entries with <b>single</b> matches <b>by name</b> were automatically selected (no records will be created)",
+                    "match.by.name.single": "{{param}} entries with <b>single</b> matches <b>by name</b> were selected (no records will be created)",
                     "match.by.pui": "{{param}} entries with matches <b>by PUI</b> were automatically selected (no records will be created)",
                     "inventory": "{{param}} lots will be created",
                     "progenitors": "{{param}} entries will be connected with progenitors"


### PR DESCRIPTION
Single matches will now appear in modal if no auto-selection is checked.
This behavior is more consistent with the description of the checkbox (_Automatically select existing matches_), which does not mention whether they are single or multi.