### PR TITLE
IBP-5386: some missing authorizations in routes (label print, germplasm selector)

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-manager.route.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-manager.route.ts
@@ -4,7 +4,7 @@ import { RouteAccessService } from '../shared';
 import { GermplasmManagerComponent } from './germplasm-manager.component';
 import { GermplasmSearchComponent } from './germplasm-search.component';
 import { GermplasmSearchResolvePagingParams } from './germplasm-search-resolve-paging-params';
-import { CREATE_INVENTORY_LOT_PERMISSIONS, IMPORT_GERMPLASM_UPDATES_PERMISSIONS, SEARCH_GERMPLASM_PERMISSIONS } from '../shared/auth/permissions';
+import { CREATE_INVENTORY_LOT_PERMISSIONS, GERMPLASM_SELECTOR_PERMISSIONS, IMPORT_GERMPLASM_UPDATES_PERMISSIONS, SEARCH_GERMPLASM_PERMISSIONS } from '../shared/auth/permissions';
 import { breedingMethodRoutes } from '../entities/breeding-method/breeding-method.route';
 import { GermplasmSelectorComponent } from './selector/germplasm-selector.component';
 import { GermplasmListCreationPopupComponent } from './germplasm-list/germplasm-list-creation-popup.component';
@@ -45,7 +45,7 @@ export const GERMPLASM_MANAGER_ROUTES: Routes = [
     {
         path: 'germplasm-selector',
         component: GermplasmSelectorComponent,
-        data: { authorities: SEARCH_GERMPLASM_PERMISSIONS },
+        data: { authorities: GERMPLASM_SELECTOR_PERMISSIONS },
         canActivate: [RouteAccessService],
         resolve: {
             'pagingParams': GermplasmSearchResolvePagingParams

--- a/src/main/jhipster/src/main/webapp/app/label-printing/label-printing.route.ts
+++ b/src/main/jhipster/src/main/webapp/app/label-printing/label-printing.route.ts
@@ -2,7 +2,7 @@ import { Routes } from '@angular/router';
 
 import { LabelPrintingComponent } from './label-printing.component';
 import { RouteAccessService } from '../shared';
-import { LOT_LABEL_PRINTING_PERMISSIONS, GERMPLASM_LABEL_PRINTING_PERMISSIONS } from '../shared/auth/permissions';
+import { GERMPLASM_LABEL_PRINTING_PERMISSIONS, GERMPLASM_LIST_LABEL_PRINTING_PERMISSIONS, LOT_LABEL_PRINTING_PERMISSIONS } from '../shared/auth/permissions';
 
 export const LABEL_PRINTING_ROUTES: Routes = [
   {
@@ -14,7 +14,8 @@ export const LABEL_PRINTING_ROUTES: Routes = [
         'STUDIES',
         'MANAGE_STUDIES',
         ...LOT_LABEL_PRINTING_PERMISSIONS,
-        ...GERMPLASM_LABEL_PRINTING_PERMISSIONS
+        ...GERMPLASM_LABEL_PRINTING_PERMISSIONS,
+        ...GERMPLASM_LIST_LABEL_PRINTING_PERMISSIONS
       ]
     },
     canActivate: [RouteAccessService]

--- a/src/main/jhipster/src/main/webapp/app/shared/auth/permissions.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/auth/permissions.ts
@@ -143,3 +143,21 @@ export const MANAGE_GERMPLASM_LIST_PERMISSION = [
 export const SEARCH_GERMPLASM_LISTS_PERMISSION = [
     ...MANAGE_GERMPLASM_LIST_PERMISSION, 'SEARCH_GERMPLASM_LISTS'
 ];
+
+export const GERMPLASM_LIST_LABEL_PRINTING_PERMISSIONS = [
+    ...MANAGE_GERMPLASM_LIST_PERMISSION,
+    'GERMPLASM_LIST_LABEL_PRINTING'
+];
+
+/**
+ * To simplify, we don't specify here which specific granular permission
+ * needs access to the germplasm selector (e.g ADD_GERMPLASM_LIST_ENTRIES),
+ * we just add the "View" type permission that gives access to the module.
+ */
+export const GERMPLASM_SELECTOR_PERMISSIONS = [
+    ...SEARCH_GERMPLASM_PERMISSIONS,
+    ...SEARCH_GERMPLASM_LISTS_PERMISSION,
+    ...MANAGE_STUDIES_PERMISSIONS,
+    'QUERIES',
+    'GRAPHICAL_QUERIES',
+];


### PR DESCRIPTION
- allow germplasm list in label printing
- fix authorization for germplasm selector: allow graphical queries, manage studies and germplasm list