### PR TITLE
IBP-5310: Refactor tree.component / new germplasm list folder selector

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/app.module.ts
+++ b/src/main/jhipster/src/main/webapp/app/app.module.ts
@@ -14,8 +14,6 @@ import { ErrorComponent, JhiMainComponent, PageRibbonComponent } from './layouts
 import { LabelPrintingModule } from './label-printing/label-printing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { GermplasmManagerModule } from './germplasm-manager/germplasm-manager.module';
-import { GermplasmTreeTableComponent } from './shared/tree/germplasm/germplasm-tree-table.component';
-import { StudyTreeComponent } from './shared/tree/study/study-tree.component';
 import { AuthExpiredInterceptor } from './blocks/interceptor/auth-expired.interceptor';
 import { InventoryDetailsModule } from './germplasm-manager/inventory/details/inventory-details.module';
 import { NavbarModule } from './navbar/navbar.module';
@@ -27,7 +25,6 @@ import { PrototypeModule } from './prototype/prototype.module';
 import { VariableDetailsModule } from './ontology/variable-details/variable-details.module';
 import { MetadataManagerModule } from './metadata-manager/metadata-manager.module';
 import { GermplasmListModule } from './germplasm-list/germplasm-list.module';
-import { GermplasmListTreeTableComponent } from './shared/tree/germplasm/germplasm-list-tree-table.component';
 import { AboutModule } from './about/about.module';
 
 @NgModule({
@@ -56,15 +53,9 @@ import { AboutModule } from './about/about.module';
     declarations: [
         JhiMainComponent,
         PageRibbonComponent,
-        ErrorComponent,
-        GermplasmTreeTableComponent,
-        GermplasmListTreeTableComponent,
-        StudyTreeComponent
+        ErrorComponent
     ],
     entryComponents: [
-        GermplasmTreeTableComponent,
-        GermplasmListTreeTableComponent,
-        StudyTreeComponent
     ],
     providers: [
         RouteAccessService,

--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/list.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/list.component.html
@@ -48,6 +48,11 @@
 						jhiTranslate="germplasm-list.list-data.actions.clone-list"
 						(click)="openCloneGermplasmList()" data-test="cloneListButton">
 					</button>
+					<button [hidden]="this.germplasmList?.locked" class="dropdown-item" type="submit"
+							jhiTranslate="germplasm-list.list-data.actions.move-to-folder"
+							*jhiHasAnyAuthority="EDIT_LIST_METADATA_PERMISSIONS"
+							(click)="moveToFolder()" data-test="moveToFolderButton">
+					</button>
 					<button class="dropdown-item" type="submit" *jhiHasAnyAuthority="GERMPLASM_LIST_LABEL_PRINTING_PERMISSIONS"
 							jhiTranslate="germplasm-list.list-data.actions.export-data-and-labels"
 							(click)="exportDataAndLabels()" data-test="exportListButton">

--- a/src/main/jhipster/src/main/webapp/app/germplasm-list/list.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-list/list.component.ts
@@ -34,12 +34,16 @@ import { GermplasmSearchRequest } from '../entities/germplasm/germplasm-search-r
 import { GermplasmListDataSearchRequest } from '../entities/germplasm-list-data/germplasm-list-data-search-request.model';
 import { GermplasmListMetadataComponent } from './germplasm-list-metadata.component';
 import { GermplasmListManagerContext } from './germplasm-list-manager.context';
+import { GermplasmListFolderSelectorComponent } from '../shared/tree/germplasm/germplasm-list-folder-selector.component';
+import { TreeComponentResult } from '../shared/tree';
+import { GermplasmTreeService } from '../shared/tree/germplasm/germplasm-tree.service';
 
 declare var $: any;
 
 @Component({
     selector: 'jhi-list',
-    templateUrl: './list.component.html'
+    templateUrl: './list.component.html',
+    providers: [{ provide: GermplasmTreeService, useClass: GermplasmTreeService }]
 })
 export class ListComponent implements OnInit {
 
@@ -54,6 +58,7 @@ export class ListComponent implements OnInit {
     DELETE_LIST_PERMISSIONS = [...MANAGE_GERMPLASM_LIST_PERMISSION, 'DELETE_GERMPLASM_LIST'];
     CLONE_GERMPLASM_LIST_PERMISSIONS = [...MANAGE_GERMPLASM_LIST_PERMISSION, 'CLONE_GERMPLASM_LIST'];
     REMOVE_ENTRIES_GERMPLASM_LISTS_PERMISSIONS = [...MANAGE_GERMPLASM_LIST_PERMISSION, 'REMOVE_ENTRIES_GERMPLASM_LISTS'];
+    // Used also for "move to folders" for now
     EDIT_LIST_METADATA_PERMISSIONS = [...MANAGE_GERMPLASM_LIST_PERMISSION, 'EDIT_LIST_METADATA'];
     ADMIN_PERMISSIONS = ['ADMIN'];
 
@@ -162,6 +167,7 @@ export class ListComponent implements OnInit {
                 private jhiLanguageService: JhiLanguageService,
                 private eventManager: JhiEventManager,
                 private germplasmListService: GermplasmListService,
+                private germplasmTreeService: GermplasmTreeService,
                 private router: Router,
                 private alertService: AlertService,
                 public principal: Principal,
@@ -520,6 +526,16 @@ export class ListComponent implements OnInit {
                 },
                 (error) => this.onError(error)
             );
+    }
+
+    moveToFolder() {
+        const modal = this.modalService.open(GermplasmListFolderSelectorComponent as Component, { size: 'lg', backdrop: 'static' });
+        modal.result.then((result: TreeComponentResult[]) => {
+            this.germplasmTreeService.move(String(this.listId), String(result[0].id), false).subscribe(
+                () => this.alertService.success('germplasm-list.list-data.move-to-folder.success'),
+                (error) => this.onError(error)
+            );
+        });
     }
 
     private getFilters() {

--- a/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-list/germplasm-list-add.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-manager/germplasm-list/germplasm-list-add.component.ts
@@ -46,7 +46,8 @@ export class GermplasmListAddComponent extends TreeComponent {
                 private eventManager: JhiEventManager,
                 private germplasmListManagerContext: GermplasmListManagerContext
     ) {
-        super(false, service, modal, alertService, translateService, modalService);
+        // TODO See if it's possible and makes sense to use selectedNodes and selectionMode from base component
+        super(false, 'single', service, modal, alertService, translateService, modalService);
         if (!this.paramContext.cropName) {
             this.paramContext.readParams();
         }

--- a/src/main/jhipster/src/main/webapp/app/shared/list-creation/germplasm-list-clone.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/list-creation/germplasm-list-clone.component.ts
@@ -84,7 +84,7 @@ export class GermplasmListCloneComponent extends ListCreationComponent implement
             description: this.model.description,
             listType: this.model.type,
             notes: this.model.notes,
-            parentFolderId: this.selectedNode.data.id
+            parentFolderId: this.selectedNodes[0].data.id
         });
 
         this._isLoading = true;

--- a/src/main/jhipster/src/main/webapp/app/shared/list-creation/list-creation.component.html
+++ b/src/main/jhipster/src/main/webapp/app/shared/list-creation/list-creation.component.html
@@ -43,7 +43,7 @@
 			<div class="clearfix"></div>
 			<div class="table-responsive">
 				<p-tree [value]="nodes"
-						[(selection)]="this.selectedNode"
+						[(selection)]="_selectedNodes"
 						[draggableNodes]="true"
 						[droppableNodes]="true"
 						[validateDrop]="true"
@@ -51,7 +51,7 @@
 						(onNodeDrop)="onNodeDrop($event, $event.dragNode, $event.dropNode)"
 						(onNodeExpand)="onNodeExpand($event)"
 						autoLayout="true"
-						selectionMode="single"
+						[selectionMode]="selectionMode"
 						draggableScope="self"
 						droppableScope="self"
 						styleClass="tree-table">

--- a/src/main/jhipster/src/main/webapp/app/shared/list-creation/list-creation.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/list-creation/list-creation.component.ts
@@ -43,7 +43,7 @@ export abstract class ListCreationComponent extends TreeComponent implements OnI
                 public calendar: NgbCalendar,
                 public modalService: NgbModal,
                 public principal: Principal) {
-        super(true, treeService, modal, alertService, translateService, modalService);
+        super(true, 'single', treeService, modal, alertService, translateService, modalService);
         if (!this.paramContext.cropName) {
             this.paramContext.readParams();
         }
@@ -129,13 +129,4 @@ export abstract class ListCreationComponent extends TreeComponent implements OnI
     isSelectable(node: TreeNode) {
         return node.isFolder;
     }
-
-    set selectedNode(node: PrimeNgTreeNode) {
-        this.selectedNodes[0] = node;
-    }
-
-    get selectedNode(): PrimeNgTreeNode {
-        return this.selectedNodes[0];
-    }
-
 }

--- a/src/main/jhipster/src/main/webapp/app/shared/shared.module.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/shared.module.ts
@@ -82,6 +82,10 @@ import { VariableSelectModalComponent } from './variable-container/variable-sele
 import { FileDeleteOptionsComponent } from './file/component/file-delete-options.component';
 import { RouterModule } from '@angular/router';
 import { GermplasmListCloneComponent } from './list-creation/germplasm-list-clone.component';
+import { GermplasmTreeTableComponent } from './tree/germplasm/germplasm-tree-table.component';
+import { GermplasmListTreeTableComponent } from './tree/germplasm/germplasm-list-tree-table.component';
+import { StudyTreeComponent } from './tree/study/study-tree.component';
+import { GermplasmListFolderSelectorComponent } from './tree/germplasm/germplasm-list-folder-selector.component';
 
 @NgModule({
     imports: [
@@ -90,6 +94,7 @@ import { GermplasmListCloneComponent } from './list-creation/germplasm-list-clon
         ReactiveFormsModule,
         TableModule,
         TreeModule,
+        TreeTableModule,
         DragDropModule,
         CdkDragDropModule,
         LeafletModule,
@@ -127,6 +132,10 @@ import { GermplasmListCloneComponent } from './list-creation/germplasm-list-clon
         AttributeSelect2DataPipe,
         ItemCountCustomComponent,
         LocationSelect2DataPipe,
+        GermplasmTreeTableComponent,
+        GermplasmListTreeTableComponent,
+        StudyTreeComponent,
+        GermplasmListFolderSelectorComponent,
         ListBuilderComponent,
         GermplasmListCreationComponent,
         GermplasmListCloneComponent,
@@ -185,6 +194,10 @@ import { GermplasmListCloneComponent } from './list-creation/germplasm-list-clon
         ModalComponent,
         ModalConfirmComponent,
         FileDeleteOptionsComponent,
+        GermplasmTreeTableComponent,
+        GermplasmListTreeTableComponent,
+        StudyTreeComponent,
+        GermplasmListFolderSelectorComponent,
         GermplasmListCreationComponent,
         GermplasmListCloneComponent,
         SampleListCreationComponent,
@@ -229,6 +242,10 @@ import { GermplasmListCloneComponent } from './list-creation/germplasm-list-clon
         ColumnFilterDropdownComponent,
         ItemCountCustomComponent,
         LocationSelect2DataPipe,
+        GermplasmTreeTableComponent,
+        GermplasmListTreeTableComponent,
+        StudyTreeComponent,
+        GermplasmListFolderSelectorComponent,
         ListBuilderComponent,
         GermplasmListCreationComponent,
         GermplasmListCloneComponent,

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-list-folder-selector.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-list-folder-selector.component.ts
@@ -20,8 +20,7 @@ export class GermplasmListFolderSelectorComponent extends TreeComponent {
                 public alertService: AlertService,
                 public translateService: TranslateService,
                 public modalService: NgbModal) {
-        super(false, service, activeModal, alertService, translateService, modalService);
+        super(false, 'single', service, activeModal, alertService, translateService, modalService);
         this.isFolderSelectionMode = true;
-        this.selectionMode = 'single';
     }
 }

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-list-folder-selector.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-list-folder-selector.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { TreeService } from '../tree.service';
+import { GermplasmTreeService } from './germplasm-tree.service';
+import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { AlertService } from '../../alert/alert.service';
+import { TranslateService } from '@ngx-translate/core';
+import { TreeComponent } from '../tree.component';
+
+@Component({
+    selector: 'jhi-germplasm-list-folder-selector',
+    templateUrl: '../tree-table.component.html',
+    providers: [{ provide: TreeService, useClass: GermplasmTreeService }]
+})
+export class GermplasmListFolderSelectorComponent extends TreeComponent {
+
+    title = 'Select folder';
+
+    constructor(public service: TreeService,
+                public activeModal: NgbActiveModal,
+                public alertService: AlertService,
+                public translateService: TranslateService,
+                public modalService: NgbModal) {
+        super(false, service, activeModal, alertService, translateService, modalService);
+        this.isFolderSelectionMode = true;
+        this.selectionMode = 'single';
+    }
+}

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-list-tree-table.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-list-tree-table.component.ts
@@ -20,6 +20,6 @@ export class GermplasmListTreeTableComponent extends TreeComponent {
                 public alertService: AlertService,
                 public translateService: TranslateService,
                 public modalService: NgbModal) {
-        super(false, service, activeModal, alertService, translateService, modalService);
+        super(false, 'multiple', service, activeModal, alertService, translateService, modalService);
     }
 }

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-tree-table.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-tree-table.component.ts
@@ -21,6 +21,6 @@ export class GermplasmTreeTableComponent extends TreeComponent {
                 public alertService: AlertService,
                 public translateService: TranslateService,
                 public modalService: NgbModal) {
-        super(true, service, activeModal, alertService, translateService, modalService);
+        super(true, 'multiple', service, activeModal, alertService, translateService, modalService);
     }
 }

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-tree.service.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-tree.service.ts
@@ -55,9 +55,9 @@ export class GermplasmTreeService extends TreeService {
             newParentId: target
         };
         /*
-         * TODO Review backend. program should be sent always to resolve permissions
+         * TODO IBP-5412. program should be sent always to resolve permissions
          *  but doing so while moving to folders inside crop section throws an error.
-         *  May/may not relates to IBP-5285
+         *  May be fixed by IBP-5285
          */
         if (!isParentCropList && this.paramContext.programUUID) {
             params['programUUID'] = this.paramContext.programUUID;
@@ -80,6 +80,11 @@ export class GermplasmTreeService extends TreeService {
             folderName,
             parentId
         };
+        /*
+         * TODO IBP-5412. program should be sent always to resolve permissions
+         *  but doing so while moving to folders inside crop section throws an error.
+         *  May be fixed by IBP-5285
+         */
         if (!isParentCropList && this.paramContext.programUUID) {
             params['programUUID'] = this.paramContext.programUUID;
         }

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-tree.service.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/germplasm/germplasm-tree.service.ts
@@ -54,6 +54,11 @@ export class GermplasmTreeService extends TreeService {
         const params = {
             newParentId: target
         };
+        /*
+         * TODO Review backend. program should be sent always to resolve permissions
+         *  but doing so while moving to folders inside crop section throws an error.
+         *  May/may not relates to IBP-5285
+         */
         if (!isParentCropList && this.paramContext.programUUID) {
             params['programUUID'] = this.paramContext.programUUID;
         }

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/study/study-tree.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/study/study-tree.component.ts
@@ -20,6 +20,6 @@ export class StudyTreeComponent extends TreeComponent {
                 public alertService: AlertService,
                 public translateService: TranslateService,
                 public modalService: NgbModal) {
-        super(false, service, activeModal, alertService, translateService, modalService);
+        super(false, 'multiple', service, activeModal, alertService, translateService, modalService);
     }
 }

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/tree-table.component.html
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/tree-table.component.html
@@ -86,5 +86,5 @@
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-default" data-dismiss="modal" (click)="closeModal()">Cancel</button>
-    <button type="button" class="btn btn-primary" aria-hidden="true" (click)="finish()">Ok</button>
+    <button type="button" class="btn btn-primary" aria-hidden="true" [disabled]="!selectedNodes.length" (click)="finish()">Ok</button>
 </div>

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/tree-table.component.html
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/tree-table.component.html
@@ -39,9 +39,9 @@
             <div class="table-responsive" >
                 <p-treeTable [value]="nodes"
                              (onNodeExpand)="onNodeExpand($event)"
-                             selectionMode="multiple"
+                             [selectionMode]="selectionMode"
                              autoLayout="true"
-                             [(selection)]="this.selectedNodes"
+                             [(selection)]="this._selectedNodes"
                              (onNodeSelect)="onNodeSelect($event)"
                              styleClass="tree-table">
                     <ng-template pTemplate="header">
@@ -86,5 +86,5 @@
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-default" data-dismiss="modal" (click)="closeModal()">Cancel</button>
-    <button type="button" class="btn btn-primary" aria-hidden="true" (click)="selectLists()">Ok</button>
+    <button type="button" class="btn btn-primary" aria-hidden="true" (click)="finish()">Ok</button>
 </div>

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/tree.component.html
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/tree.component.html
@@ -10,7 +10,7 @@
             <div class="table-responsive">
                 <p-tree [value]="nodes"
                         (onNodeExpand)="onNodeExpand($event)"
-                        selectionMode="multiple"
+                        [selectionMode]="selectionMode"
                         autoLayout="true"
                         [(selection)]="_selectedNodes"
                         (onNodeSelect)="onNodeSelect($event)"

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/tree.component.html
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/tree.component.html
@@ -12,7 +12,7 @@
                         (onNodeExpand)="onNodeExpand($event)"
                         selectionMode="multiple"
                         autoLayout="true"
-                        [(selection)]="this.selectedNodes"
+                        [(selection)]="_selectedNodes"
                         (onNodeSelect)="onNodeSelect($event)"
                         styleClass="tree-table">
                     <ng-template pTemplate="default" let-node>
@@ -26,5 +26,5 @@
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-default" data-dismiss="modal" (click)="closeModal()">Cancel</button>
-    <button type="button" class="btn btn-primary" aria-hidden="true" (click)="selectLists()">Ok</button>
+    <button type="button" class="btn btn-primary" aria-hidden="true" (click)="finish()">Ok</button>
 </div>

--- a/src/main/jhipster/src/main/webapp/app/shared/tree/tree.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/tree/tree.component.ts
@@ -9,6 +9,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { HttpErrorResponse } from '@angular/common/http';
 
 declare var $: any;
+export type SelectionMode = 'single' | 'multiple';
 
 export class TreeComponent implements OnInit {
 
@@ -19,7 +20,6 @@ export class TreeComponent implements OnInit {
     mode: Mode = Mode.None;
     Modes = Mode;
     isFolderSelectionMode = false;
-    selectionMode: 'single' | 'multiple' = 'multiple';
 
     public nodes: PrimeNgTreeNode[] = [];
     name: string;
@@ -30,7 +30,7 @@ export class TreeComponent implements OnInit {
         if (!this._selectedNodes) {
             return [];
         }
-        if (this.selectionMode === 'multiple') {
+        if (this.selectionMode === 'multiple' && 'length' in this._selectedNodes) {
             return this._selectedNodes as PrimeNgTreeNode[];
         }
         return [this._selectedNodes as PrimeNgTreeNode];
@@ -43,6 +43,7 @@ export class TreeComponent implements OnInit {
     private draggedNode: PrimeNgTreeNode;
 
     constructor(public isReadOnly: boolean,
+                public selectionMode: SelectionMode,
                 public service: TreeService,
                 public activeModal: NgbActiveModal,
                 public alertService: AlertService,

--- a/src/main/jhipster/src/main/webapp/i18n/en/germplasm-list.json
+++ b/src/main/jhipster/src/main/webapp/i18n/en/germplasm-list.json
@@ -37,7 +37,8 @@
                 "add-to-list": "Add to list",
                 "delete-list": "Delete list",
                 "clone-list": "Clone list",
-                "remove-entries": "Remove entries"
+                "remove-entries": "Remove entries",
+                "move-to-folder": "Move to folder"
             },
             "selection": {
                 "empty": "Please select at least one entry."
@@ -68,6 +69,9 @@
                 "confirm.message": "Are you sure you want to remove the selected entries from the list?",
                 "confirm.header": "Remove entries",
                 "remove.success": "Successfully removed entries."
+            },
+            "move-to-folder": {
+                "success": "Successfully moved to folder"
             }
         },
         "variables": {


### PR DESCRIPTION
Refactor:
- Getter for selectedNodes: a common interface to return array for both
single and multiple selections
- enable 'single' primeng tree selectionmode
- isFolderSelectionMode: show and select only folders
- common modal result interface
- move tree components declaration to shared module (import
primeng TreeTableModule there to make it possible)

New germplasm list folder selector:
- use new mechanisms to select only folders and return the selection