### PR TITLE
IBP-4553 IBP-4526 navbar routing

### DIFF
--- a/src/main/jhipster/src/main/webapp/app/entities/create-program/create-program-dialog.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/entities/create-program/create-program-dialog.component.ts
@@ -82,7 +82,11 @@ export class CreateProgramDialogComponent implements OnInit, OnDestroy {
             programBasicDetails['breedingLocationDefaultId'] = this.breedingLocationDefaultId;
             programBasicDetails['storageLocationDefaultId'] = this.storageLocationDefaultId;
             this.programService.addProgram(programBasicDetails, this.cropName).subscribe((program) => {
-                    const message: NavbarMessageEvent = { programSelected: program, toolSelected: '/ibpworkbench/controller/jhipster#program-settings-manager' };
+                    const message: NavbarMessageEvent = {
+                        programSelected: program,
+                        toolSelectedUrl: '/ibpworkbench/controller/jhipster#program-settings-manager',
+                        toolSelectedName: 'Manage Program Settings'
+                    };
                     window.parent.postMessage(message, '*');
                     this.alertService.success('program.create.success');
                 }, (res: HttpErrorResponse) => {

--- a/src/main/jhipster/src/main/webapp/app/entities/program/my-studies.component.html
+++ b/src/main/jhipster/src/main/webapp/app/entities/program/my-studies.component.html
@@ -23,7 +23,7 @@
 					<tr *ngFor="let study of studies" [class.selected]="study.selected"
 						(mouseenter)="onMouseEnter(study)">
 						<td>
-							<a href (click)="urlService.openStudy(study.studyId, context.program)">
+							<a href (click)="urlService.openStudy(study.studyId, study.name, context.program)">
 								{{study.name}}
 							</a>
 						</td>

--- a/src/main/jhipster/src/main/webapp/app/entities/program/program.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/entities/program/program.component.ts
@@ -14,6 +14,7 @@ import { NavbarMessageEvent } from '../../shared/model/navbar-message.event';
 import { MANAGE_STUDIES_VIEW_PERMISSIONS, SEARCH_GERMPLASM_LISTS_PERMISSION } from '../../shared/auth/permissions';
 import { Select2OptionData } from 'ng-select2';
 import { ProgramUsageService } from '../../shared/service/program-usage.service';
+import { ParamContext } from '../../shared/service/param.context';
 
 @Component({
     selector: 'jhi-program',
@@ -60,14 +61,21 @@ export class ProgramComponent implements OnInit {
         private languageService: JhiLanguageService,
         private router: Router,
         private route: ActivatedRoute,
+        private paramContext: ParamContext,
         public context: ProgramContext,
         public programUsageService: ProgramUsageService,
     ) {
     }
 
     async ngOnInit() {
+        /*
+         * specially needed for history.back that comes with programUUID params and no crop,
+         * thus causing an error in identity()
+         */
+        this.paramContext.clear();
         const identity = await this.principal.identity();
         this.user = identity;
+
         this.crops = await this.cropService.getCrops().toPromise();
 
         this.programUsageService.getLastestSelectedProgram(this.user.id).toPromise().then((response) => {

--- a/src/main/jhipster/src/main/webapp/app/germplasm-details/basic-details/basic-details-pane.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-details/basic-details/basic-details-pane.component.html
@@ -121,7 +121,7 @@
 						</thead>
 						<tbody>
 						<tr>
-							<td><a *ngIf="germplasmDetailsContext.isModal && isStudyClickable(germplasm?.germplasmOrigin?.programUUID)" href (click)="urlService.openStudy(germplasm?.germplasmOrigin?.studyId)">{{germplasm?.germplasmOrigin?.studyName}}</a>
+							<td><a *ngIf="germplasmDetailsContext.isModal && isStudyClickable(germplasm?.germplasmOrigin?.programUUID)" href (click)="urlService.openStudy(germplasm?.germplasmOrigin?.studyId, germplasm?.germplasmOrigin?.studyName)">{{germplasm?.germplasmOrigin?.studyName}}</a>
 								<span *ngIf="germplasmDetailsContext.isModal && !isStudyClickable(germplasm?.germplasmOrigin?.programUUID)" class="btn btn-link disabled p-0">{{germplasm?.germplasmOrigin?.studyName}}</span>
 								<span *ngIf="!germplasmDetailsContext.isModal">{{germplasm?.germplasmOrigin?.studyName}}</span></td>
 							<td>{{germplasm?.germplasmOrigin?.observationUnitId}}</td>

--- a/src/main/jhipster/src/main/webapp/app/germplasm-details/observations/observations-pane.component.html
+++ b/src/main/jhipster/src/main/webapp/app/germplasm-details/observations/observations-pane.component.html
@@ -11,7 +11,7 @@
 					</thead>
 					<tbody>
 					<tr *ngFor="let study of studies">
-						<td><a *ngIf="germplasmDetailsContext.isModal && isClickable(study)" href (click)="urlService.openStudy(study.studyId)">{{study.name}}</a>
+						<td><a *ngIf="germplasmDetailsContext.isModal && isClickable(study)" href (click)="urlService.openStudy(study.studyId, study.name)">{{study.name}}</a>
 							<span *ngIf="germplasmDetailsContext.isModal && !isClickable(study)" class="btn btn-link disabled p-0">{{study.name}}</span>
 							<span *ngIf="!germplasmDetailsContext.isModal">{{study.name}}</span>
 						</td>

--- a/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.html
+++ b/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.html
@@ -60,7 +60,7 @@
 				<!-- This is the tree node template for leaf nodes -->
 				<mat-tree-node class="leaf" [class.selected]="toolLinkSelected.startsWith(node.link)"
 							   *matTreeNodeDef="let node" matTreeNodePadding matTreeNodePaddingIndent="34"
-							   (click)="openTool(node.link)">
+							   (click)="openTool(node.link, node.name)">
 					{{node.name}}
 				</mat-tree-node>
 			</mat-tree>

--- a/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.html
+++ b/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.html
@@ -9,8 +9,8 @@
 		<span>{{program?.name}}</span>
 		<div class="toolbar-filler"></div>
 		<button mat-button (click)="siteAdmin()" *jhiHasAnyAuthority="SITE_ADMIN_PERMISSIONS">Site Admin</button>
-		<button mat-button *ngIf="toolUrl" (click)="myPrograms()">My Programs</button>
-		<ng-container *ngIf="!toolUrl">
+		<button mat-button *ngIf="toolLinkSelected" (click)="myPrograms()">My Programs</button>
+		<ng-container *ngIf="!toolLinkSelected">
 			<button mat-button (click)="addProgram()" *jhiHasAnyAuthority="ADD_PROGRAM_PERMISSION"><i class="fa fa-plus"></i> Add a Program</button>
 		</ng-container>
 
@@ -67,8 +67,7 @@
 			<div *ngIf="version" class="version">{{version}}</div>
 		</mat-sidenav>
 		<mat-sidenav-content>
-			<iframe #viewport name="PID_Sbrowser" *ngIf="toolUrl" [src]="toolUrl" style="border: 0; width: 100%; height: 100%"></iframe>
-			<iframe *ngIf="!toolUrl" src="/ibpworkbench/main/#programs" style="border: 0; width: 100%; height: 100%"></iframe>
+			<iframe #viewport name="PID_Sbrowser" id="viewport" src="about:blank" style="border: 0; width: 100%; height: 100%"></iframe>
 		</mat-sidenav-content>
 	</mat-sidenav-container>
 </div>

--- a/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.html
+++ b/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.html
@@ -8,10 +8,10 @@
 		</button>
 		<span>{{program?.name}}</span>
 		<div class="toolbar-filler"></div>
-		<button mat-button (click)="siteAdmin()" *jhiHasAnyAuthority="SITE_ADMIN_PERMISSIONS">Site Admin</button>
-		<button mat-button *ngIf="toolLinkSelected" (click)="myPrograms()">My Programs</button>
+		<button mat-button (click)="siteAdmin()" *jhiHasAnyAuthority="SITE_ADMIN_PERMISSIONS" data-test="siteAdminButton">Site Admin</button>
+		<button mat-button *ngIf="toolLinkSelected" (click)="myPrograms()" data-test="myProgramsButton">My Programs</button>
 		<ng-container *ngIf="!toolLinkSelected">
-			<button mat-button (click)="addProgram()" *jhiHasAnyAuthority="ADD_PROGRAM_PERMISSION"><i class="fa fa-plus"></i> Add a Program</button>
+			<button mat-button (click)="addProgram()" *jhiHasAnyAuthority="ADD_PROGRAM_PERMISSION" data-test="addProgramButton"><i class="fa fa-plus"></i> Add a Program</button>
 		</ng-container>
 
 		<button mat-icon-button (click)="about()">

--- a/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
@@ -321,16 +321,33 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         }
     }
 
+    /**
+     * Restores route after login or page reload
+     */
     private async restoreRoute() {
-        const queryParams = sessionStorage.getItem(this.SESSION_STORAGE_QUERY_PARAM_KEY);
-        if (queryParams) {
-            await this.router.navigateByUrl(queryParams);
-            sessionStorage.removeItem(this.SESSION_STORAGE_QUERY_PARAM_KEY);
+        let programUUID = this.route.snapshot.queryParams.programUUID;
+        let cropName = this.route.snapshot.queryParams.cropName;
+        let toolUrl = this.route.snapshot.queryParams.toolUrl;
+
+        const hasQueryParams = () => {
+            return (programUUID && cropName) || toolUrl;
         }
 
-        const programUUID = this.route.snapshot.queryParams.programUUID;
-        const cropName = this.route.snapshot.queryParams.cropName;
-        const toolUrl = this.route.snapshot.queryParams.toolUrl;
+        const sessionQueryParams = sessionStorage.getItem(this.SESSION_STORAGE_QUERY_PARAM_KEY);
+        sessionStorage.removeItem(this.SESSION_STORAGE_QUERY_PARAM_KEY);
+
+        if (sessionQueryParams && !hasQueryParams()) {
+            await this.router.navigateByUrl(sessionQueryParams);
+
+            programUUID = this.route.snapshot.queryParams.programUUID;
+            cropName = this.route.snapshot.queryParams.cropName;
+            toolUrl = this.route.snapshot.queryParams.toolUrl;
+        }
+
+        if (!hasQueryParams()) {
+            return;
+        }
+
         let program: Program;
         if (cropName && programUUID) {
             program = await this.programService.getProgramByProgramUUID(cropName, programUUID).toPromise().then((resp) => resp.body);

--- a/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
@@ -55,6 +55,8 @@ export class NavbarComponent implements OnInit, AfterViewInit {
     );
     dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
 
+    private readonly SESSION_STORAGE_QUERY_PARAM_KEY = 'bms.queryParams';
+
     constructor(
         private navService: NavService,
         private principal: Principal,
@@ -104,6 +106,7 @@ export class NavbarComponent implements OnInit, AfterViewInit {
                 skipLocationChange: true,
                 queryParamsHandling: 'merge'
             });
+            sessionStorage.removeItem(this.SESSION_STORAGE_QUERY_PARAM_KEY)
             return;
         }
 
@@ -292,7 +295,25 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         });
     }
 
+    @HostListener('window:beforeunload')
+    private beforeunload() {
+        this.persistQueryParams();
+    }
+
+    private persistQueryParams() {
+        const queryIndex = this.router.url.lastIndexOf('?');
+        if (queryIndex >= 0) {
+            sessionStorage.setItem(this.SESSION_STORAGE_QUERY_PARAM_KEY, this.router.url.substring(queryIndex));
+        }
+    }
+
     private async restoreRoute() {
+        const queryParams = sessionStorage.getItem(this.SESSION_STORAGE_QUERY_PARAM_KEY);
+        if (queryParams) {
+            await this.router.navigateByUrl(queryParams);
+            sessionStorage.removeItem(this.SESSION_STORAGE_QUERY_PARAM_KEY);
+        }
+
         const programUUID = this.route.snapshot.queryParams.programUUID;
         const cropName = this.route.snapshot.queryParams.cropName;
         const toolUrl = this.route.snapshot.queryParams.toolUrl;

--- a/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
+++ b/src/main/jhipster/src/main/webapp/app/navbar/navbar.component.ts
@@ -88,6 +88,10 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         // Get ask for support link url
         this.getHelpLink(this.askForSupportHelpLink, HELP_NAVIGATION_ASK_FOR_SUPPORT)
             .then((response) => this.askForSupportHelpLink = response);
+
+        this.location.subscribe((popStateEvent) => {
+            this.onPopStateEvent(popStateEvent);
+        })
     }
 
     hasChild = (_: number, node: any) => node.expandable;
@@ -117,10 +121,6 @@ export class NavbarComponent implements OnInit, AfterViewInit {
         }
 
         this.restoreRoute();
-
-        this.location.subscribe((popStateEvent) => {
-            this.onPopStateEvent(popStateEvent);
-        })
     }
 
     ngAfterViewInit() {

--- a/src/main/jhipster/src/main/webapp/app/shared/login/login.service.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/login/login.service.ts
@@ -15,7 +15,7 @@ export class LoginService {
     }
 
     forceLogout() {
-        alert('Site Admin needs  to authenticate you again. Redirecting to login page.');
+        alert('Breeding Management System needs to authenticate you again. Redirecting to login page.');
         this.logout();
     }
 

--- a/src/main/jhipster/src/main/webapp/app/shared/model/navbar-message.event.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/model/navbar-message.event.ts
@@ -4,6 +4,7 @@ export interface NavbarMessageEvent {
     programSelected?: Program,
     programUpdated?: Program,
     programDeleted?: any,
-    toolSelected?: string,
+    toolSelectedUrl?: string,
+    toolSelectedName?: string,
     userProfileChanged?: boolean
 }

--- a/src/main/jhipster/src/main/webapp/app/shared/service/param.context.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/service/param.context.ts
@@ -20,6 +20,13 @@ export class ParamContext {
         this.loggedInUserId = Number(queryParams.loggedInUserId);
     }
 
+    clear() {
+        this.cropName = null;
+        this.programUUID = null;
+        this.selectedProjectId = null;
+        this.loggedInUserId = null;
+    }
+
     /**
      * Workaround until https://github.com/angular/angular/issues/12664
      */

--- a/src/main/jhipster/src/main/webapp/app/shared/service/url.service.ts
+++ b/src/main/jhipster/src/main/webapp/app/shared/service/url.service.ts
@@ -6,17 +6,19 @@ import { Program } from '../program/model/program';
 @Injectable()
 export class UrlService {
 
-    openStudy(studyId: any, program: Program = null) {
+    openStudy(studyId: any, studyName: string, program: Program = null) {
         let message: NavbarMessageEvent;
         if (program) {
             message = {
                 programSelected: program,
-                toolSelected: STUDY_URL + studyId
+                toolSelectedUrl: STUDY_URL + studyId,
+                toolSelectedName: 'Study: ' + studyName
             }
         } else {
             // TODO untested
             message = {
-                toolSelected: STUDY_URL + studyId
+                toolSelectedUrl: STUDY_URL + studyId,
+                toolSelectedName: 'Study: ' + studyName
             }
         }
         window.top.postMessage(message, '*');
@@ -30,12 +32,14 @@ export class UrlService {
         if (program) {
             message = {
                 programSelected: program,
-                toolSelected: url
+                toolSelectedUrl: url,
+                toolSelectedName: 'List: ' + listName
             }
         } else {
             // TODO untested
             message = {
-                toolSelected: url
+                toolSelectedUrl: url,
+                toolSelectedName: 'List: ' + listName
             }
         }
         window.top.postMessage(message, '*');


### PR DESCRIPTION

- navigate on openTool() (adds params to main navbar route)
- restore params on reload and after login (keeps params in session storage)
- Refactor: add tool name as param to openTool
- iframe.contentWindow.location.replace instead of angular binding to src (aavoid putting another entry in the window's history)